### PR TITLE
Sepolicy : Enable /sys/class/thermal/ access permission .

### DIFF
--- a/domain.te
+++ b/domain.te
@@ -1,2 +1,5 @@
 allow domain sysfs_socinfo:dir r_dir_perms;
 allow domain sysfs_socinfo:file r_file_perms;
+
+# Allow all domains read access to sysfs_thermal
+r_dir_file(domain, sysfs_thermal);

--- a/file_contexts
+++ b/file_contexts
@@ -20,3 +20,6 @@
 /boot     		     u:object_r:rootfs:s0
 /persistent		     u:object_r:rootfs:s0
 /gpt.igeneric.ini     u:object_r:rootfs:s0
+
+/sys/class/thermal(/.*)?             u:object_r:sysfs_thermal:s0
+/sys/module/thermal(/.*)?            u:object_r:sysfs_thermal:s0


### PR DESCRIPTION
When do adb sideload in recovery mode, there is an error "E: Failed to
scandir /sys/class/thermal/: Permission denied". There is enable the
file access permission with SElinux sepolicy.

Tracked-On: OAM-76587
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>