### PR TITLE
[DO Not Merge] Add a rule to allow GFX to access /vendor/hwc.lock

### DIFF
--- a/graphics/project-celadon/hal_graphics_composer_default.te
+++ b/graphics/project-celadon/hal_graphics_composer_default.te
@@ -14,3 +14,4 @@ allow hal_graphics_composer_default gpu_device:dir r_dir_perms;
 allow hal_graphics_composer_default gpu_device:chr_file rw_file_perms;
 allow hal_graphics_composer_default sysfs_app_readable:file r_file_perms;
 allow hal_graphics_composer_default hwc_info_service:service_manager add;
+allow hal_graphics_composer_default vendor_file:file r_file_perms;


### PR DESCRIPTION
Add a selinux rule to allow HWC to open and lock /vendor/hwc.lock

Change-Id: I997b920045ac8cb0a458df36a1dee486a92db6ef
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>