### PR TITLE
[Thermal]: Added missing sepolicy for thermal

### DIFF
--- a/thermal/device.te
+++ b/thermal/device.te
@@ -1,0 +1,1 @@
+type thermal_device, dev_type;

--- a/thermal/dptf/dptf.te
+++ b/thermal/dptf/dptf.te
@@ -1,0 +1,54 @@
+# Rules for esif_ufd
+type dptf, domain;
+type dptf_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(dptf);
+
+# Need to use vendor binder
+vndbinder_use(dptf)
+binder_call(dptf, hal_thermal_default)
+
+# Allow dptf to find the thermal_hal_service service
+allow dptf thermal_hal_service:service_manager find;
+
+# Allow raw socket
+# Also requires DAC changes in device/intel/common/filesystem_config/android_filesystem_config.h
+allow dptf self:capability { net_raw };
+
+# Allow network access for DPTF UI
+net_domain(dptf)
+
+# Allow create and listen to uevent socket
+allow dptf self:netlink_kobject_uevent_socket create_socket_perms;
+allowxperm dptf self:netlink_kobject_uevent_socket ioctl SIOCETHTOOL;
+
+# Vendor directory
+# /vendor/lib64
+# /vendor/app and /vendor/etc/dptf/dv direcroty
+allow dptf vendor_file:dir r_dir_perms;
+allow dptf vendor_file:file rx_file_perms;
+
+# Data directory
+allow dptf dptf_data_file:dir create_dir_perms;
+allow dptf dptf_data_file:file create_file_perms;
+
+#
+# Sysfs files
+#
+allow dptf sysfs:dir r_dir_perms;
+allow dptf sysfs_devices_system_cpu:file rw_file_perms;
+allow dptf sysfs_powercap:{ file lnk_file } rw_file_perms;
+allow dptf sysfs_powercap:dir { read open search};
+allow dptf sysfs_powercap:dir r_dir_perms;
+allow dptf sysfs_dptf_file:dir r_dir_perms;
+allow dptf sysfs_dptf_file:file rw_file_perms;
+allow dptf sysfs_thermal_management:dir r_dir_perms;
+allow dptf sysfs_thermal_management:file rw_file_perms;
+allow dptf sysfs_thermal:file r_file_perms;
+allow dptf sysfs_thermal:file w_file_perms;
+
+# /sys/class/backlight/intel_backlight/brigthness
+# /sys/class/power_supply/bq*/max_charge_current
+allow dptf sysfs:file rw_file_perms;
+
+# Set properties
+set_prop(dptf, powerctl_prop)

--- a/thermal/dptf/file.te
+++ b/thermal/dptf/file.te
@@ -1,0 +1,2 @@
+type dptf_data_file, file_type, data_file_type;
+type sysfs_dptf_file, fs_type, sysfs_type;

--- a/thermal/dptf/file_contexts
+++ b/thermal/dptf/file_contexts
@@ -1,0 +1,4 @@
+/data/misc/dptf(/.*)?           u:object_r:dptf_data_file:s0
+/etc/dptf(/.*)?                 u:object_r:dptf_data_file:s0
+(/system)?/vendor/bin/esif_ufd  u:object_r:dptf_exec:s0
+/vendor/bin/thermal_lite        u:object_r:thermal_lite_exec:s0

--- a/thermal/dptf/system_server.te
+++ b/thermal/dptf/system_server.te
@@ -1,0 +1,4 @@
+# permission needed for sensor service to access thermal sensors
+allow system_server sysfs_thermal_management:dir rw_dir_perms;
+allow system_server sysfs_thermal_management:file rw_file_perms;
+#for last_reboot_reason

--- a/thermal/dptf/thermal_lite.te
+++ b/thermal/dptf/thermal_lite.te
@@ -1,0 +1,17 @@
+#
+# thermal_lite
+#
+
+type thermal_lite, domain;
+type thermal_lite_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(thermal_lite)
+
+allow thermal_lite sysfs:dir r_dir_perms;
+allow thermal_lite sysfs_thermal_management:dir r_dir_perms;
+allow thermal_lite sysfs_thermal_management:file r_file_perms;
+allow thermal_lite sysfs_powercap:file rw_file_perms;
+allow thermal_lite sysfs_powercap:dir r_dir_perms;
+allow thermal_lite sysfs_thermal:file rw_file_perms;
+
+# properties
+set_prop(thermal_lite, powerctl_prop)

--- a/thermal/file.te
+++ b/thermal/file.te
@@ -1,0 +1,2 @@
+type sysfs_thermal_management, fs_type, sysfs_type;
+type sysfs_powercap, fs_type, sysfs_type;

--- a/thermal/file_contexts
+++ b/thermal/file_contexts
@@ -1,0 +1,12 @@
+/sys/devices/virtual/thermal/thermal_zone[0-9]/trip_point_[0-9]_temp u:object_r:sysfs_thermal:s0
+/sys/devices/virtual/thermal/cooling_device[0-9]/cur_state u:object_r:sysfs_thermal:s0
+/sys/devices/virtual/thermal/thermal_zone[0-9]/policy u:object_r:sysfs_thermal:s0
+/sys/devices/virtual/thermal/thermal_zone[0-9]/temp u:object_r:sysfs_thermal:s0
+/sys/devices/system/cpu/cpu[0-4]/cpufreq/thermal_scaling_max_freq u:object_r:sysfs_thermal:s0
+
+/dev/acpi_thermal_rel       u:object_r:thermal_device:s0
+
+# thermal management
+/sys/devices/platform/coretemp.0(/.*)? u:object_r:sysfs_thermal_management:s0
+/sys/devices/virtual/thermal(/.*)?     u:object_r:sysfs_thermal_management:s0
+/sys/devices/virtual/powercap(/.*)?  u:object_r:sysfs_powercap:s0

--- a/thermal/hal_sensors_sefault.te
+++ b/thermal/hal_sensors_sefault.te
@@ -1,0 +1,4 @@
+allow hal_sensors_default sysfs_thermal_management:dir r_dir_perms;
+allow hal_sensors_default sysfs_thermal_management:file rw_file_perms;
+
+allow system_server system_app:file w_file_perms;

--- a/thermal/hal_thermal_default.te
+++ b/thermal/hal_thermal_default.te
@@ -1,0 +1,15 @@
+#============= hal_thermal_default ==============
+vndbinder_use(hal_thermal_default)
+
+add_service(hal_thermal_default, thermal_hal_service)
+
+allow hal_thermal_default thermal_hal_service:hwservice_manager find;
+allow hal_thermal_default sysfs_thermal_management:dir r_dir_perms;
+allow hal_thermal_default sysfs_thermal:file r_file_perms;
+allow hal_thermal_default proc_stat:file r_file_perms;
+allow hal_thermal_default self:can_socket create_socket_perms;
+allowxperm hal_thermal_default self:can_socket ioctl {
+  SIOCGIFINDEX
+  SIOCSIFNAME
+  SIOCSIFFLAGS
+};

--- a/thermal/platform_app.te
+++ b/thermal/platform_app.te
@@ -1,0 +1,7 @@
+#
+# platform_app
+#
+
+# XXX Did the thermal apps drop out of the system app domain?
+allow platform_app sysfs_powercap:dir search;
+allow platform_app sysfs_powercap:file r_file_perms;

--- a/thermal/system_app.te
+++ b/thermal/system_app.te
@@ -1,0 +1,22 @@
+#
+# system_app.te
+#
+
+# XXX Not sure which app this is for, so common for now
+allow system_app sysfs_thermal:file rw_file_perms;
+allow system_app thermal_device:chr_file rw_file_perms;
+allow system_app sysfs_thermal_management:{ file lnk_file } rw_file_perms;
+allow system_app sysfs_thermal_management:dir {read open search };
+allow system_app sysfs_devices_system_cpu:file rw_file_perms;
+allow system_app kernel:capability net_admin;
+
+allow system_app sysfs_powercap:{ file lnk_file } rw_file_perms;
+allow system_app sysfs_powercap:dir r_dir_perms;
+
+module_only(`camera_ipu2', `
+  set_prop(system_app, cam_flash_thrtl_prop)
+')
+
+module_only(`camera_ipu4', `
+  set_prop(system_app, cam_flash_thrtl_prop)
+')

--- a/thermal/thermal-daemon/file.te
+++ b/thermal/thermal-daemon/file.te
@@ -1,0 +1,4 @@
+type thermal-daemon_data_file, file_type, data_file_type;
+type sysfs_dmi_id, fs_type, sysfs_type;
+type sysfs_backlight_thermal, fs_type, sysfs_type;
+type thermal-daemon_run_dir, fs_type, data_file_type;

--- a/thermal/thermal-daemon/file_contexts
+++ b/thermal/thermal-daemon/file_contexts
@@ -1,0 +1,6 @@
+/vendor/bin/thermal-daemon        u:object_r:thermal-daemon_exec:s0
+/vendor/etc/thermal_daemon(/.*)?        u:object_r:thermal-daemon_data_file:s0
+/data/misc/thermal-daemon(/.*)?	u:object_r:thermal-daemon_run_dir:s0
+/sys/devices/virtual/dmi/id/product_name		u:object_r:sysfs_dmi_id:s0
+/sys/devices/virtual/dmi/id/product_uuid		u:object_r:sysfs_dmi_id:s0
+/sys/class/backlight(/.*)?		u:object_r:sysfs_backlight_thermal:s0

--- a/thermal/thermal-daemon/thermal-daemon.te
+++ b/thermal/thermal-daemon/thermal-daemon.te
@@ -1,0 +1,32 @@
+#
+# thermal-daemon
+#
+
+type thermal-daemon, domain;
+type thermal-daemon_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(thermal-daemon)
+
+allow thermal-daemon sysfs:dir r_dir_perms;
+allow thermal-daemon sysfs_thermal_management:dir r_dir_perms;
+allow thermal-daemon sysfs_thermal_management:file rw_file_perms;
+allow thermal-daemon sysfs_powercap:{ file lnk_file } rw_file_perms;
+allow thermal-daemon sysfs_powercap:dir r_dir_perms;
+allow thermal-daemon sysfs_thermal:dir r_dir_perms;
+allow thermal-daemon sysfs_thermal:file rw_file_perms;
+allow thermal-daemon sysfs_leds:dir r_dir_perms;
+allow thermal-daemon sysfs_leds:file rw_file_perms;
+allow thermal-daemon sysfs_backlight_thermal:dir r_dir_perms;
+allow thermal-daemon sysfs_backlight_thermal:file rw_file_perms;
+allow hal_light_default sysfs_backlight_thermal:dir r_dir_perms;
+allow hal_light_default sysfs_backlight_thermal:file rw_file_perms;
+allow thermal-daemon sysfs_dmi_id:{ file lnk_file } rw_file_perms;
+allow thermal-daemon system_data_file:dir create_dir_perms;
+allow thermal-daemon system_data_file:dir rw_dir_perms;
+allow thermal-daemon thermal-daemon_run_dir:dir create_dir_perms;
+allow thermal-daemon thermal-daemon_run_dir:file create_file_perms;
+allow thermal-daemon thermal-daemon_data_file:dir r_file_perms;
+allow thermal-daemon thermal-daemon_data_file:file r_file_perms;
+allow thermal-daemon thermal_device:chr_file rw_file_perms;
+
+# properties
+set_prop(thermal-daemon, powerctl_prop)

--- a/thermal/ueventd.te
+++ b/thermal/ueventd.te
@@ -1,0 +1,6 @@
+#
+# ueventd
+#
+
+allow ueventd sysfs_thermal_management:file rw_file_perms;
+allow ueventd sysfs_powercap:file w_file_perms;

--- a/thermal/vndservice.te
+++ b/thermal/vndservice.te
@@ -1,0 +1,1 @@
+type thermal_hal_service,    vndservice_manager_type;

--- a/thermal/vndservice_contexts
+++ b/thermal/vndservice_contexts
@@ -1,0 +1,1 @@
+thermal.hal.service    u:object_r:thermal_hal_service:s0


### PR DESCRIPTION
	- Thermal Daemon not working becuase of missing sepolicy.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-84347
Signed-off-by: ashish18590 <ashish18590@gmail.com>