### PR TITLE
Sepolicy: Health HAL supports multi-platform

### DIFF
--- a/health_hal/file_contexts
+++ b/health_hal/file_contexts
@@ -1,1 +1,1 @@
-/vendor/bin/hw/android\.hardware\.health@2\.0-service\.gordon_peak          u:object_r:hal_health_default_exec:s0
+/vendor/bin/hw/android\.hardware\.health@2\.0-service\.(.*)?          u:object_r:hal_health_default_exec:s0


### PR DESCRIPTION
Health HAL needs to support multi-platform because each platform has
its own configuration.
Health HAL will have different name in different platform.
For example, android.hardware.health@2.0-service.gordon_peak
This patch changes the selinux policy to support the generic health HAL name.

Tracked-On: OAM-84554
Signed-off-by: Sun Xinx xinx.sun@intel.com