### PR TITLE
Enable the default DRM

### DIFF
--- a/drm-default/file_contexts
+++ b/drm-default/file_contexts
@@ -1,0 +1,1 @@
+/vendor/bin/hw/android\.hardware\.drm@1\.2-service\.clearkey          u:object_r:hal_drm_clearkey_exec:s0

--- a/drm-default/hal_drm_clearkey.te
+++ b/drm-default/hal_drm_clearkey.te
@@ -1,0 +1,11 @@
+# policy for /vendor/bin/hw/android.hardware.drm@1.2-service.clearkey
+type hal_drm_clearkey, domain;
+type hal_drm_clearkey_exec, exec_type, vendor_file_type, file_type;
+
+init_daemon_domain(hal_drm_clearkey)
+
+hal_server_domain(hal_drm_clearkey, hal_drm)
+
+vndbinder_use(hal_drm_clearkey);
+
+allow hal_drm_clearkey { appdomain -isolated_app }:fd use;

--- a/drm-default/hal_drm_default.te
+++ b/drm-default/hal_drm_default.te
@@ -1,0 +1,1 @@
+vndbinder_use(hal_drm_default)


### PR DESCRIPTION
CTS reqiures feature DRM, so enable the default one.
This is for sepolicy part.

Change-Id: I3ae31256345bfef8e27aa70f5c3719854bbc1adf
Tracked-On: OAM-84905
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>