### PR TITLE
Remove cp_ss

### DIFF
--- a/trusty/file_contexts
+++ b/trusty/file_contexts
@@ -4,5 +4,4 @@
 /dev/rpmb[01]           u:object_r:tee_device:s0
 
 /vendor/bin/storageproxyd    u:object_r:tee_exec:s0
-/vendor/bin/cp_ss   u:object_r:tee_exec:s0
 /data/vendor/securestorage(/.*)?    u:object_r:tee_data_file:s0

--- a/trusty/property.te
+++ b/trusty/property.te
@@ -1,3 +1,0 @@
-type tee_service_prop, property_type;
-
-

--- a/trusty/property_contexts
+++ b/trusty/property_contexts
@@ -1,2 +1,0 @@
-ro.vendor.copy.ss  u:object_r:tee_service_prop:s0
-

--- a/trusty/tee.te
+++ b/trusty/tee.te
@@ -9,7 +9,3 @@
 allow tee self:capability sys_rawio;
 allow tee block_device:dir search;
 allow tee tee_device:blk_file rw_file_perms;
-allow tee vendor_shell_exec:file execute_no_trans;
-allow tee vendor_toolbox_exec:file execute_no_trans;
-allow tee system_data_file:file read;
-set_prop(tee, tee_service_prop);

--- a/trusty/vendor_init.te
+++ b/trusty/vendor_init.te
@@ -1,1 +1,0 @@
-allow vendor_init system_data_file:file r_file_perms;


### PR DESCRIPTION
This module is only required for the OTA across pre-P to P or successors.
No requirement of O->Q now.
And it will cause to ATS failure due to sepolicy.

Change-Id: Id4d2abf087d7fd4c324fc39bcf201693fb68cf63
Signed-off-by: Huang Yang <yang.huang@intel.com>
Tracked-On: OAM-86820