### PR TITLE
[postinstall] Resolve neverallow issue

### DIFF
--- a/abota/efi/postinstall.te
+++ b/abota/efi/postinstall.te
@@ -2,8 +2,6 @@ recovery_only(`
   allow postinstall rootfs:file rx_file_perms;
 ')
 
-allow postinstall vendor_shell_exec:file rx_file_perms;
-allow postinstall vendor_toolbox_exec:file rx_file_perms;
 allow postinstall rootfs:dir mounton;
 allow postinstall self:capability sys_admin;
 allow postinstall vfat:filesystem { mount unmount };


### PR DESCRIPTION
Resolve build error:
neverallow on line 8 of system/sepolicy/public/vendor_toolbox.te
(or line 27338 of policy.conf) violated by allow postinstall
vendor_toolbox_exec:file { execute execute_no_trans };

neverallow on line 942 of system/sepolicy/public/domain.te
(or line 12340 of policy.conf) violated by allow postinstall
vendor_shell_exec:file { execute execute_no_trans };

EB 4570 test pass

Tracked-On: OAM-86848
Signed-off-by: Heng Luo <heng.luo@intel.com>