### PR TITLE
Add the permission to set the property service.adb.tcp.port

### DIFF
--- a/ethernet/common/vendor_init.te
+++ b/ethernet/common/vendor_init.te
@@ -1,0 +1,4 @@
+
+userdebug_or_eng(`
+allow vendor_init shell_prop:property_service set;
+')


### PR DESCRIPTION
Add sepolicy for below failure "avc:  denied  { set } for
property=service.adb.tcp.port pid=2245 uid=0 gid=0
scontext=u:r:vendor_init:s0 tcontext=u:object_r:shell_prop:
s0 tclass=property_service permissive=0

Tracked-On: OAM-86782
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>