### PR TITLE
SEPolicy: Fix some avc errors

### DIFF
--- a/vendor/dumpstate.te
+++ b/vendor/dumpstate.te
@@ -1,0 +1,3 @@
+dontaudit dumpstate sysfs:file read;
+dontaudit dumpstate device:file write;
+dontaudit dumpstate unlabeled:file read;


### PR DESCRIPTION
dumpstate doesn't need to read/write the file type of
sysfs, device and unlabeled. Disable the print statements
related with these file types.

Tracked-On: OAM-86940
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>