### PR TITLE
Enable selinux for caas

### DIFF
--- a/aafd/aafd.te
+++ b/aafd/aafd.te
@@ -2,3 +2,32 @@
 type aafd, domain;
 type aafd_exec, exec_type, file_type, vendor_file_type;
 init_daemon_domain(aafd)
+
+allow aafd proc_cmdline:file r_file_perms;
+allow aafd self:netlink_kobject_uevent_socket create_socket_perms;
+allowxperm aafd self:netlink_kobject_uevent_socket ioctl SIOCETHTOOL;
+
+allow aafd self:capability { net_admin sys_module };
+allow aafd sysfs:dir r_dir_perms;
+allow aafd sysfs:file rw_file_perms;
+allow aafd sysfs_app_readable:dir r_dir_perms;
+allow aafd sysfs_app_readable:file rw_file_perms;
+allow aafd sysfs_devices_system_cpu:file w_file_perms;
+allow aafd sysfs_dm:dir r_dir_perms;
+allow aafd sysfs_dm:file w_file_perms;
+allow aafd sysfs_dt_firmware_android:dir r_dir_perms;
+allow aafd sysfs_health2_0_management:dir r_dir_perms;
+allow aafd sysfs_health2_0_management:file w_file_perms;
+allow aafd sysfs_hwrandom:dir r_dir_perms;
+allow aafd sysfs_hwrandom:file w_file_perms;
+allow aafd sysfs_loop:dir r_dir_perms;
+allow aafd sysfs_loop:file w_file_perms;
+allow aafd sysfs_net:dir r_dir_perms;
+allow aafd sysfs_net:file w_file_perms;
+allow aafd sysfs_rtc:dir r_dir_perms;
+allow aafd sysfs_rtc:file w_file_perms;
+allow aafd sysfs_thermal_management:dir r_dir_perms;
+allow aafd sysfs_thermal_management:file w_file_perms;
+allow aafd sysfs_zram:dir r_dir_perms;
+allow aafd sysfs_zram_uevent:file w_file_perms;
+allow aafd vendor_file:system module_load;

--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -1,0 +1,12 @@
+allow logwrapper vendor_shell_exec:file rx_file_perms;
+allow logwrapper vendor_toolbox_exec:file rx_file_perms;
+allow logwrapper vendor_file:file rx_file_perms;
+allow logwrapper sysfs:file r_file_perms;
+allow logwrapper proc:file r_file_perms;
+allow logwrapper kernel:system module_request;
+
+allow logwrapper self:bluetooth_socket create_socket_perms_no_ioctl;
+
+set_prop(logwrapper, vendor_graphics_hwcomposer_prop)
+set_prop(logwrapper, vendor_video_codec_prop)
+

--- a/aafd/mediacodec.te
+++ b/aafd/mediacodec.te
@@ -1,0 +1,1 @@
+get_prop(mediacodec, vendor_video_codec_prop)

--- a/aafd/property.te
+++ b/aafd/property.te
@@ -1,0 +1,1 @@
+type vendor_video_codec_prop, property_type;

--- a/aafd/property_contexts
+++ b/aafd/property_contexts
@@ -1,0 +1,1 @@
+vendor.intel.video.codec u:object_r:vendor_video_codec_prop:s0

--- a/aafd/vendor_init.te
+++ b/aafd/vendor_init.te
@@ -1,0 +1,1 @@
+set_prop(vendor_init, vendor_video_codec_prop)

--- a/crashlogd/logsvc.te
+++ b/crashlogd/logsvc.te
@@ -7,9 +7,6 @@ userdebug_or_eng(`
   allow logsvc self:capability { sys_nice };
   allow logsvc self:capability2 syslog;
 
-  allow logsvc log_file:file create_file_perms;
-  allow logsvc log_file:dir rw_dir_perms;
-
   allow logsvc logdr_socket:sock_file write;
   allow logsvc logd:unix_stream_socket connectto;
 
@@ -21,15 +18,20 @@ userdebug_or_eng(`
   set_prop(logsvc, vendor_elogs_prop)
   set_prop(logsvc, logpersistd_logging_prop)
 
-  allow logsvc cache_file:dir r_dir_perms;
-  allow logsvc cache_file:file r_file_perms;
-  allow logsvc log_file:lnk_file create_file_perms;
   allow logsvc misc_logd_file:file getattr;
   permissive logsvc;
 
   dontaudit logsvc self:capability *;
   dontaudit logsvc misc_logd_file:dir *;
   dontaudit logsvc sysfs:file *;
+  dontaudit logsvc cache_file:file *;
+  dontaudit logsvc cache_file:dir rw_dir_perms;
+  dontaudit logsvc cache_file:lnk_file create_file_perms;
+  dontaudit logsvc log_file:file create_file_perms;
+  dontaudit logsvc log_file:dir *;
+  dontaudit logsvc log_file:lnk_file create_file_perms;
+  dontaudit logsvc vendor_apklogfs_prop:file create_file_perms;
+  dontaudit logsvc vendor_aplogfs_prop:file create_file_perms;
 
   allow logsvc vendor_toolbox_exec:file execute_no_trans;
   allow logsvc logd_socket:sock_file write;

--- a/debug-phonedoctor/crashreport_app.te
+++ b/debug-phonedoctor/crashreport_app.te
@@ -26,7 +26,12 @@ userdebug_or_eng(`
   dontaudit crashreport_app vendor_core_prop:file *;
   dontaudit crashreport_app runtime_event_log_tags_file:file *;
   dontaudit crashreport_app vendor_crashlogd_prop:file *;
+  dontaudit crashreport_app activity_service:service_manager find;
+  dontaudit crashreport_app autofill_service:service_manager find;
+  dontaudit crashreport_app dropbox_service:service_manager find;
+  dontaudit crashreport_app log_file:lnk_file create_file_perms;
 
 # any rules that violate neverallows can go here
   dontaudit crashreport_app serialno_prop:file r_file_perms;
+  dontaudit crashreport_app cgroup:file *;
 ')

--- a/graphics/mesa/bootanim.te
+++ b/graphics/mesa/bootanim.te
@@ -1,3 +1,4 @@
 allow bootanim gpu_device:chr_file rw_file_perms;
 allow bootanim gpu_device:dir r_dir_perms;
 allow bootanim sysfs_app_readable:file r_file_perms;
+allow bootanim tmpfs:file r_file_perms;

--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -21,6 +21,7 @@
 /(vendor|system/vendor)/lib(64)?/libpciaccess\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libskuwa\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.broxton\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/hw/gralloc\.intel\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libgrallocclient\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libglapi\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/i965_dri\.so u:object_r:same_process_hal_file:s0

--- a/graphics/mesa/genfs_contexts
+++ b/graphics/mesa/genfs_contexts
@@ -1,2 +1,3 @@
 genfscon proc /driver/i915rpm/i915_rpm_op u:object_r:proc_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:02.0/ u:object_r:sysfs_app_readable:s0
+genfscon sysfs /devices/pci0000:00/0000:00:01.0/ u:object_r:sysfs_app_readable:s0

--- a/graphics/mesa/hal_graphics_allocator_default.te
+++ b/graphics/mesa/hal_graphics_allocator_default.te
@@ -1,3 +1,5 @@
 #============= hal_graphics_allocator_default ==============
 allow hal_graphics_allocator_default gpu_device:chr_file rw_file_perms;
 allow hal_graphics_allocator_default gpu_device:dir r_dir_perms;
+allow hal_graphics_allocator_default graphics_device:chr_file rw_file_perms;
+allow hal_graphics_allocator_default graphics_device:dir r_dir_perms;

--- a/graphics/mesa/hal_graphics_composer_default.te
+++ b/graphics/mesa/hal_graphics_composer_default.te
@@ -19,3 +19,6 @@ allow hal_graphics_composer_default hal_graphics_mapper_hwservice:hwservice_mana
 hal_client_domain(hal_graphics_composer_default, hal_graphics_allocator)
 allow hal_graphics_composer_default sysfs_app_readable:file r_file_perms;
 allow hal_graphics_composer_default vendor_file:file r_file_perms;
+
+set_prop(hal_graphics_composer_default, vendor_graphics_hwcomposer_prop)
+dontaudit hal_graphics_composer_default default_prop:file *;

--- a/graphics/mesa/property.te
+++ b/graphics/mesa/property.te
@@ -1,0 +1,1 @@
+type vendor_graphics_hwcomposer_prop, property_type;

--- a/graphics/mesa/property_contexts
+++ b/graphics/mesa/property_contexts
@@ -1,0 +1,1 @@
+ro.graphics.hwcomposer.    u:object_r:vendor_graphics_hwcomposer_prop:s0

--- a/intel_prop/intel_prop.te
+++ b/intel_prop/intel_prop.te
@@ -5,6 +5,12 @@ type intel_prop, domain;
 type intel_prop_exec, exec_type, file_type, vendor_file_type;
 init_daemon_domain(intel_prop)
 
-# XXX /sys/firmware/dmi/entries/0-0/raw
-allow intel_prop sysfs:file r_file_perms;
+# wrap sepolicy rules for intel_prop with userdebug_or_eng,
+# since intel_prop isn't used in user build.
+userdebug_or_eng(`
+  # XXX /sys/firmware/dmi/entries/0-0/raw
+  allow intel_prop sysfs:file r_file_perms;
 
+  allow intel_prop proc:file r_file_perms;
+  set_prop(intel_prop, powerctl_prop)
+')

--- a/load_modules/load_modules.te
+++ b/load_modules/load_modules.te
@@ -18,6 +18,12 @@ allow load_modules rootfs:file r_file_perms;
 allow load_modules system_data_file:dir getattr;
 allow load_modules system_lib_file:file rx_file_perms;
 allow load_modules vendor_file:file rx_file_perms;
+allow load_modules debugfs_wifi_tracing:dir search;
+
+# load_modules cannot set & get sys.usb.config now, it
+# would better move these operations to init.rc
+dontaudit load_modules exported_system_radio_prop:file *;
+dontaudit coredomain load_modules:key view;
 
 not_full_treble(`
     allow load_modules shell_exec:file rx_file_perms;

--- a/power/genfs_contexts
+++ b/power/genfs_contexts
@@ -1,0 +1,1 @@
+genfscon sysfs /devices/pci0000:00/0000:00:01.0/drm/card0/gt_act_freq_mhz u:object_r:sysfs_power:s0

--- a/power/hal_power_service.te
+++ b/power/hal_power_service.te
@@ -6,3 +6,4 @@ init_daemon_domain(hal_power_service)
 
 allow hal_power_service cgroup:file rw_file_perms;
 allow hal_power_service sysfs_devices_system_cpu:file rw_file_perms;
+allow hal_power_service sysfs_power:file r_file_perms;

--- a/psdapp/file_contexts
+++ b/psdapp/file_contexts
@@ -1,2 +1,1 @@
 /vendor/bin/psdapp          u:object_r:psdapp_exec:s0
-/vendor/bin/logwrapper      u:object_r:logwrapper_exec:s0

--- a/psdapp/psdapp.te
+++ b/psdapp/psdapp.te
@@ -2,6 +2,7 @@ type psdapp, domain;
 type psdapp_exec, exec_type, file_type, vendor_file_type;
 
 init_daemon_domain(psdapp)
+domain_auto_trans(logwrapper, psdapp_exec, psdapp)
 
 allow psdapp sysfs:file r_file_perms;
 allow psdapp logwrapper:fd use;

--- a/thermal/property.te
+++ b/thermal/property.te
@@ -1,0 +1,1 @@
+type vendor_thermal_prop, property_type;

--- a/thermal/property_contexts
+++ b/thermal/property_contexts
@@ -1,0 +1,1 @@
+persist.thermal.    u:object_r:vendor_thermal_prop:s0

--- a/thermal/vendor_init.te
+++ b/thermal/vendor_init.te
@@ -1,0 +1,1 @@
+set_prop(vendor_init, vendor_thermal_prop)

--- a/vendor/adbd.te
+++ b/vendor/adbd.te
@@ -1,0 +1,2 @@
+allow adbd kernel:system module_request;
+set_prop(adbd, ctl_start_prop)

--- a/vendor/bootanim.te
+++ b/vendor/bootanim.te
@@ -1,0 +1,1 @@
+allow bootanim tmpfs:file { read write };

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -1,0 +1,1 @@
+/vendor/bin/logwrapper      u:object_r:logwrapper_exec:s0

--- a/vendor/filesystem.te
+++ b/vendor/filesystem.te
@@ -1,0 +1,1 @@
+allow proc_net proc:filesystem associate;

--- a/vendor/flags_health_check.te
+++ b/vendor/flags_health_check.te
@@ -1,0 +1,6 @@
+get_prop(flags_health_check, apexd_prop)
+get_prop(flags_health_check, bluetooth_a2dp_offload_prop)
+get_prop(flags_health_check, bluetooth_prop)
+get_prop(flags_health_check, bluetooth_audio_hal_prop)
+
+dontaudit flags_health_check property_type:file *;

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -1,3 +1,4 @@
 #sysfs
+genfscon sysfs /devices/pnp0/00:00/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:03/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:04/rtc   u:object_r:sysfs_rtc:s0

--- a/vendor/logwrapper.te
+++ b/vendor/logwrapper.te
@@ -4,4 +4,3 @@ type logwrapper_exec, exec_type, file_type, vendor_file_type;
 init_daemon_domain(logwrapper)
 
 allow logwrapper devpts:chr_file rw_file_perms;
-domain_auto_trans(logwrapper, psdapp_exec, psdapp)

--- a/vendor/mediacodec.te
+++ b/vendor/mediacodec.te
@@ -1,0 +1,1 @@
+dontaudit mediacodec default_prop:file *;

--- a/vendor/netd.te
+++ b/vendor/netd.te
@@ -1,0 +1,2 @@
+dontaudit netd self:capability sys_module;
+dontaudit netd kernel:system module_request;

--- a/vendor/ueventd.te
+++ b/vendor/ueventd.te
@@ -1,0 +1,1 @@
+allow ueventd debugfs_wakeup_sources:file r_file_perms;

--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -1,0 +1,4 @@
+allow vendor_init self:capability2 block_suspend;
+allow vendor_init kernel:system module_request;
+allow vendor_init debugfs_tracing_instances:dir create_dir_perms;
+allow vendor_init debugfs_tracing_instances:file w_file_perms;

--- a/vendor/vold.te
+++ b/vendor/vold.te
@@ -1,0 +1,1 @@
+allow vold mnt_vendor_file:dir r_dir_perms;

--- a/vendor/webview_zygote.te
+++ b/vendor/webview_zygote.te
@@ -1,0 +1,1 @@
+dontaudit webview_zygote app_data_file:dir getattr;


### PR DESCRIPTION
Add the required sepolicy rules for caas. caas can boot
to UI with selinux in enforcing mode.

Tracked-On: OAM-88545
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>