### PR TITLE
Remove gralloc.minigbm from sepolicy

### DIFF
--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -22,7 +22,6 @@
 /(vendor|system/vendor)/lib(64)?/libskuwa\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.broxton\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.intel\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/hw/gralloc\.minigbm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libgrallocclient\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libglapi\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/i965_dri\.so u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
For virgl, when we ust gralloc.minigbm and hwcomposer.minigbm,
ui will have some issues. Let's use ia hwc and gralloc.
This change help to remove gralloc.minigbm from sepolicy