### PR TITLE
Allow adb over network for user build

### DIFF
--- a/ethernet/common/vendor_init.te
+++ b/ethernet/common/vendor_init.te
@@ -1,4 +1,1 @@
-
-userdebug_or_eng(`
 allow vendor_init shell_prop:property_service set;
-')


### PR DESCRIPTION
For CaaS(In VM), adb currently only can be accessed over network,
so we need to modify this sepolicy to allow adb over network for
user build.

Tracked-On: OAM-88786
Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>