### PR TITLE
Fix the sepolicy permissive issue in sw launch

### DIFF
--- a/graphics/mesa/bootanim.te
+++ b/graphics/mesa/bootanim.te
@@ -2,3 +2,6 @@ allow bootanim gpu_device:chr_file rw_file_perms;
 allow bootanim gpu_device:dir r_dir_perms;
 allow bootanim sysfs_app_readable:file r_file_perms;
 allow bootanim tmpfs:file r_file_perms;
+allow bootanim graphics_device:chr_file { ioctl open read };
+allow bootanim graphics_device:dir search;
+allow bootanim self:process execmem;

--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -32,6 +32,9 @@
 /(vendor|system/vendor)/lib(64)?/libmd\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel_pri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_pri\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/egl/libEGL_swiftshader\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/egl/libGLESv1_CM_swiftshader\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/egl/libGLESv2_swiftshader\.so u:object_r:same_process_hal_file:s0
 
 #coreu /data/vendor permission
 /data/vendor/coreu(/.*)?       u:object_r:coreu_data_file:s0

--- a/graphics/mesa/hal_neuralnetworks_default.te
+++ b/graphics/mesa/hal_neuralnetworks_default.te
@@ -1,0 +1,1 @@
+allow hal_neuralnetworks_default graphics_device:dir search;

--- a/graphics/mesa/platform_app.te
+++ b/graphics/mesa/platform_app.te
@@ -1,0 +1,1 @@
+allow platform_app graphics_device:dir search;

--- a/graphics/mesa/priv_app.te
+++ b/graphics/mesa/priv_app.te
@@ -1,0 +1,1 @@
+allow priv_app graphics_device:dir search;

--- a/graphics/mesa/surfaceflinger.te
+++ b/graphics/mesa/surfaceflinger.te
@@ -23,3 +23,4 @@ allow surfaceflinger sysfs_videostatus:file { getattr w_file_perms };
 allow surfaceflinger hal_graphics_allocator_default_tmpfs:file { read write map };
 allow surfaceflinger gpu_device:dir r_dir_perms;
 allow surfaceflinger sysfs_app_readable:file r_file_perms;
+allow surfaceflinger self:process execmem;

--- a/graphics/mesa/system_app.te
+++ b/graphics/mesa/system_app.te
@@ -1,0 +1,1 @@
+allow system_app graphics_device:dir search;


### PR DESCRIPTION
After enable sepolicy, the sw launch doesn't work.
Add the swiftshader permission and rules.

Tracked-On: OAM-88897
Signed-off-by: HeYue <yue.he@intel.com>