### PR TITLE
Fixed the nn.gpgpu.vulkan property access denied issue.

### DIFF
--- a/neuralnetworks/hal_neuralnetworks.te
+++ b/neuralnetworks/hal_neuralnetworks.te
@@ -15,6 +15,8 @@ allow hal_neuralnetworks_default usb_device:chr_file rw_file_perms;
 
 allow hal_neuralnetworks_default self:netlink_kobject_uevent_socket { read bind create setopt };
 
+get_prop(hal_neuralnetworks_default, hal_neuralnetworks_prop)
+
 dontaudit hal_neuralnetworks_default self:capability { dac_read_search dac_override };
 allow hal_neuralnetworks_default sysfs:dir r_dir_perms;
 allow hal_neuralnetworks_default sysfs:file rw_file_perms;

--- a/neuralnetworks/property.te
+++ b/neuralnetworks/property.te
@@ -1,0 +1,1 @@
+type hal_neuralnetworks_prop, property_type;

--- a/neuralnetworks/property_contexts
+++ b/neuralnetworks/property_contexts
@@ -1,0 +1,1 @@
+nn.gpgpu.vulkan	u:object_r:hal_neuralnetworks_prop:s0


### PR DESCRIPTION
The nn.gpgpu.vulkan property needs to be defined in sepolicy and
make it accessible to neuralnetworks HAL.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Tracked-On: None