### PR TITLE
Sepolicy Addition for file sharing between guest OSes

### DIFF
--- a/health_hal/hal_health2_0_default.te
+++ b/health_hal/hal_health2_0_default.te
@@ -3,3 +3,4 @@
 allow hal_health_default sysfs_health2_0_management:dir r_dir_perms;
 allow hal_health_default sysfs_health2_0_management:file rw_file_perms;
 allow hal_health_default sysfs_health2_0_management:lnk_file r_file_perms;
+allow unlabeled unlabeled:filesystem associate;


### PR DESCRIPTION
Sepolicy addition for file edit and share in VM guest OSes.
For multi-VM environment.

Tracked-On: OAM-89748
Signed-off-by: tkaur <taranpreet.kaur@intel.com>