### PR TITLE
sepolicy: Add permissions for vsock

### DIFF
--- a/health_hal/hal_health2_0_default.te
+++ b/health_hal/hal_health2_0_default.te
@@ -4,3 +4,6 @@ allow hal_health_default sysfs_health2_0_management:dir r_dir_perms;
 allow hal_health_default sysfs_health2_0_management:file rw_file_perms;
 allow hal_health_default sysfs_health2_0_management:lnk_file r_file_perms;
 allow unlabeled unlabeled:filesystem associate;
+# For vsock communication with host battery utility
+allow hal_health_default self:{ socket vsock_socket } { create read write listen accept bind connect };
+allow hal_health_default unlabeled:{ socket vsock_socket } { getopt read write shutdown };

--- a/thermal/thermal-daemon/hal_thermal_intel.te
+++ b/thermal/thermal-daemon/hal_thermal_intel.te
@@ -19,3 +19,6 @@ allowxperm hal_thermal_intel self:can_socket ioctl {
   SIOCSIFFLAGS
 };
 
+#For vsock communication with host thermal utility
+allow hal_thermal_intel self:{ socket vsock_socket } { create read write listen accept bind connect };
+allow hal_thermal_intel unlabeled:{ socket vsock_socket } { getopt read write shutdown };


### PR DESCRIPTION
Thermal and health HAL in CIV depend on vsock
communication for fetching battery and thermal info
from host OS utilities. This patch adds permission
for these HALs to use vsock.

Tracked-on: OAM-90879
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>