### PR TITLE
sepolicy: adb: dbc: Enabling Sepolicy for DbCTTY

### DIFF
--- a/dbc/file_contexts
+++ b/dbc/file_contexts
@@ -1,1 +1,1 @@
-/dev/dbc_raw0	u:object_r:dbc_device:s0
+/dev/ttyDBC0	u:object_r:dbc_device:s0


### PR DESCRIPTION
Enabling the sepolicy for adb over DbC TTY for CML and EHL.
Removing sepolicy for adb over DbC RAW for CML and EHL.

Tracked-On: OAM-91335
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>