### PR TITLE
Add sepolicy for hwcomposer and gralloc

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -10,3 +10,4 @@ allow logwrapper self:bluetooth_socket create_socket_perms_no_ioctl;
 set_prop(logwrapper, vendor_graphics_hwcomposer_prop)
 set_prop(logwrapper, vendor_video_codec_prop)
 
+set_prop(logwrapper, vendor_hwcomposer_prop)

--- a/aafd/property.te
+++ b/aafd/property.te
@@ -1,1 +1,2 @@
 type vendor_video_codec_prop, property_type;
+type vendor_hwcomposer_prop, property_type;

--- a/aafd/property_contexts
+++ b/aafd/property_contexts
@@ -1,1 +1,4 @@
 vendor.intel.video.codec u:object_r:vendor_video_codec_prop:s0
+vendor.hwcomposer.set u:object_r:vendor_hwcomposer_prop:s0
+vendor.gralloc.set u:object_r:vendor_hwcomposer_prop:s0
+vendor.egl.set u:object_r:vendor_hwcomposer_prop:s0

--- a/aafd/vendor_init.te
+++ b/aafd/vendor_init.te
@@ -1,4 +1,5 @@
 set_prop(vendor_init, vendor_video_codec_prop)
+get_prop(vendor_init, vendor_hwcomposer_prop)
 
 #============= vendor_init ==============
 allow vendor_init tmpfs:dir { add_name create write };


### PR DESCRIPTION
We have some adjustments for the property setting for
hwcomposer and gralloc. Here, we add the sepolicy change
for them

Tracked-On: OAM-91001
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>