### PR TITLE
Add vendor property for hdmi audio device information

### DIFF
--- a/audio/hal_audio_default.te
+++ b/audio/hal_audio_default.te
@@ -1,0 +1,1 @@
+get_prop(hal_audio_default, vendor_default_prop)

--- a/audio/property_contexts
+++ b/audio/property_contexts
@@ -1,0 +1,1 @@
+ro.vendor.hdmi.audio    u:object_r:vendor_default_prop:s0


### PR DESCRIPTION
HDMI audio playback is not working due to incorrect
device used.

Audio HAL reads the vendor property to set hdmi audio
device for hdmi audio playback to work.

Tracked-On: OAM-91411
Signed-off-by: gkdeepa <g.k.deepa@intel.com>