### PR TITLE
Remove NN HAL sepolicy

### DIFF
--- a/graphics/mesa/hal_neuralnetworks_default.te
+++ b/graphics/mesa/hal_neuralnetworks_default.te
@@ -1,1 +1,0 @@
-allow hal_neuralnetworks_default graphics_device:dir search;


### PR DESCRIPTION
As NN inferencing not yet enabled in CIV, removing the enablement
patches to skip NNAPI CTS tests.

Tracked-On: OAM-91618
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>