### PR TITLE
sepolicy: Add permissions for adding usb-gadget through AAF

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -11,3 +11,5 @@ set_prop(logwrapper, vendor_graphics_hwcomposer_prop)
 set_prop(logwrapper, vendor_video_codec_prop)
 
 set_prop(logwrapper, vendor_hwcomposer_prop)
+
+set_prop(logwrapper, vendor_usb_controller_prop)

--- a/aafd/property.te
+++ b/aafd/property.te
@@ -1,2 +1,3 @@
 type vendor_video_codec_prop, property_type;
 type vendor_hwcomposer_prop, property_type;
+type vendor_usb_controller_prop, property_type;

--- a/aafd/property_contexts
+++ b/aafd/property_contexts
@@ -2,3 +2,4 @@ vendor.intel.video.codec u:object_r:vendor_video_codec_prop:s0
 vendor.hwcomposer.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.gralloc.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.egl.set u:object_r:vendor_hwcomposer_prop:s0
+vendor.usb.controller u:object_r:vendor_usb_controller_prop:s0

--- a/aafd/vendor_init.te
+++ b/aafd/vendor_init.te
@@ -1,5 +1,6 @@
 set_prop(vendor_init, vendor_video_codec_prop)
 get_prop(vendor_init, vendor_hwcomposer_prop)
+set_prop(vendor_init, vendor_usb_controller_prop)
 
 #============= vendor_init ==============
 allow vendor_init tmpfs:dir { add_name create write };


### PR DESCRIPTION
This patch adds required permissions to set usb-gadget
controller dynamically through AAF.

Tracked-On: OAM-91635
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>