### PR TITLE
Enable gvtg/gvtd/virtio differentiation using aaf

### DIFF
--- a/aafd/file.te
+++ b/aafd/file.te
@@ -1,0 +1,1 @@
+type p9fs, fs_type, mlstrustedobject;

--- a/aafd/genfs_contexts
+++ b/aafd/genfs_contexts
@@ -1,0 +1,1 @@
+genfscon 9p / u:object_r:p9fs:s0

--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -13,3 +13,8 @@ set_prop(logwrapper, vendor_video_codec_prop)
 set_prop(logwrapper, vendor_hwcomposer_prop)
 
 set_prop(logwrapper, vendor_usb_controller_prop)
+
+allow logwrapper p9fs:file r_file_perms;
+allow logwrapper p9fs:dir r_dir_perms;
+set_prop(logwrapper, vendor_suspend)
+set_prop(logwrapper, vendor_gpu_type)

--- a/aafd/property.te
+++ b/aafd/property.te
@@ -1,3 +1,5 @@
 type vendor_video_codec_prop, property_type;
 type vendor_hwcomposer_prop, property_type;
+type vendor_suspend, property_type;
+type vendor_gpu_type, property_type;
 type vendor_usb_controller_prop, property_type;

--- a/aafd/property_contexts
+++ b/aafd/property_contexts
@@ -2,4 +2,6 @@ vendor.intel.video.codec u:object_r:vendor_video_codec_prop:s0
 vendor.hwcomposer.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.gralloc.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.egl.set u:object_r:vendor_hwcomposer_prop:s0
+vendor.suspend u:object_r:vendor_suspend:s0
+vendor.gpu.type u:object_r:vendor_gpu_type:s0
 vendor.usb.controller u:object_r:vendor_usb_controller_prop:s0

--- a/aafd/vendor_init.te
+++ b/aafd/vendor_init.te
@@ -1,4 +1,6 @@
 set_prop(vendor_init, vendor_video_codec_prop)
+set_prop(vendor_init, vendor_suspend)
+set_prop(vendor_init, vendor_gpu_type)
 get_prop(vendor_init, vendor_hwcomposer_prop)
 set_prop(vendor_init, vendor_usb_controller_prop)
 


### PR DESCRIPTION
Changes-include:
-Adding rules for 9pfs
-Adding rules for aafd
-Set property for suspend,gpu-type

Tracked-On: OAM-91598
Signed-off-by: rnaidu <ramya.v.naidu@intel.com>
Signed-off-by: sgnanese <sundar.gnanasekaran@intel.com>
Signed-off-by: zhenlong <zhenlong.z.ji@intel.com>