### PR TITLE
allow init to create a tmpfs symlink file

### DIFF
--- a/vendor/init.te
+++ b/vendor/init.te
@@ -1,0 +1,1 @@
+allow init tmpfs:lnk_file create;


### PR DESCRIPTION
Some legacry apps still need to access /mnt/scard in the
multi-user environment. The init process link /mnt/sdcard
to /storage/self/primary in init.rc.

Tracked-On: OAM-92121
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>