### PR TITLE
Re-work sepolicy for graphic driver

### DIFF
--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -20,8 +20,7 @@
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libpciaccess\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libskuwa\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/hw/gralloc\.broxton\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/hw/gralloc\.intel\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/hw/gralloc\.celadon\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.minigbm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libgrallocclient\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libglapi\.so u:object_r:same_process_hal_file:s0
@@ -30,8 +29,6 @@
 /(vendor|system/vendor)/lib(64)?/dri/gallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/vulkan\.celadon\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libmd\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/libdrm_intel_pri\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/libdrm_pri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/egl/libEGL_swiftshader\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/egl/libGLESv1_CM_swiftshader\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/egl/libGLESv2_swiftshader\.so u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
Remove some un-used library from sepolicy, and change gralloc
sepolicy from "intel" to "celadon".

Tracked-On: OAM-92961
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>