### PR TITLE
Enable selinux for android 11 on Celadon

### DIFF
--- a/graphics/mesa/surfaceflinger.te
+++ b/graphics/mesa/surfaceflinger.te
@@ -21,6 +21,8 @@ not_full_treble(`
 allow surfaceflinger sysfs_videostatus:file { getattr w_file_perms };
 
 allow surfaceflinger hal_graphics_allocator_default_tmpfs:file { read write map };
+allow surfaceflinger hal_graphics_composer_default:dir search;
+allow surfaceflinger hal_graphics_composer_default:file read;
 allow surfaceflinger gpu_device:dir r_dir_perms;
 allow surfaceflinger sysfs_app_readable:file r_file_perms;
 allow surfaceflinger self:process execmem;

--- a/light/hal_light_default.te
+++ b/light/hal_light_default.te
@@ -1,2 +1,3 @@
 # allow hal_light_default set brightness for light module
 allow hal_light_default sysfs_backlight:file rw_file_perms;
+allow hal_light_default sysfs_backlight_thermal:dir search;

--- a/power/hal_power_default.te
+++ b/power/hal_power_default.te
@@ -1,2 +1,3 @@
 allow hal_power_default sysfs:file rw_file_perms;
 allow hal_power_default sysfs_devices_system_cpu:file rw_file_perms;
+allow hal_power_default cgroup:file read;

--- a/vendor/adbd.te
+++ b/vendor/adbd.te
@@ -1,2 +1,3 @@
 allow adbd kernel:system module_request;
+allow adbd self:vsock_socket { accept bind listen };
 set_prop(adbd, ctl_start_prop)


### PR DESCRIPTION
Need to add some sepolicy rules to make Celadon work
normally.

Tracked-On: OAM-92984
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>