### PR TITLE
Add sepolicy for IA hwcomposer

### DIFF
--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -20,6 +20,7 @@
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libpciaccess\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libskuwa\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/hw/gralloc\.intel\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.celadon\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.minigbm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libgrallocclient\.so u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
This is to help add sepolicy for hwcomposer.intel.so

Tracked-On: OAM-93101
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>