### PR TITLE
Fix sepolicy issue for SW rendering on Android R

### DIFF
--- a/graphics/mesa/surfaceflinger.te
+++ b/graphics/mesa/surfaceflinger.te
@@ -22,7 +22,7 @@ allow surfaceflinger sysfs_videostatus:file { getattr w_file_perms };
 
 allow surfaceflinger hal_graphics_allocator_default_tmpfs:file { read write map };
 allow surfaceflinger hal_graphics_composer_default:dir search;
-allow surfaceflinger hal_graphics_composer_default:file read;
+allow surfaceflinger hal_graphics_composer_default:file { read getattr open };
 allow surfaceflinger gpu_device:dir r_dir_perms;
 allow surfaceflinger sysfs_app_readable:file r_file_perms;
 allow surfaceflinger self:process execmem;

--- a/graphics/mesa/system_server.te
+++ b/graphics/mesa/system_server.te
@@ -3,3 +3,4 @@ allow system_server platform_app:file { read write };
 allow system_server priv_app:file { read write };
 allow system_server gpu_device:dir r_dir_perms;
 allow system_server sysfs_app_readable:file r_file_perms;
+allow system_server self:process execmem;


### PR DESCRIPTION
After we switch to Android R, one sepolicy issue blocks
SW rendering. This change help to fix the issue and launch
SW rendering successfully.

Tracked-On: OAM-94311
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>