### PR TITLE
[DONOT MERGE] Add Sepolicy related changes for Gatekeeper HAL

### DIFF
--- a/gatekeeperSW/file_contexts
+++ b/gatekeeperSW/file_contexts
@@ -1,0 +1,1 @@
+/vendor/bin/hw/android\.hardware\.gatekeeper@1\.0-service\.software  u:object_r:hal_gatekeeper_default_exec:s0


### PR DESCRIPTION
This patch adds sepolicy changes for Gatekeeper HAL
when trusty is disabled.

Tracked-On: OAM-94278
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>