### PR TITLE
Update property names of vendor properties

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -17,4 +17,3 @@ set_prop(logwrapper, vendor_usb_controller_prop)
 allow logwrapper p9fs:file r_file_perms;
 allow logwrapper p9fs:dir r_dir_perms;
 set_prop(logwrapper, vendor_suspend)
-set_prop(logwrapper, vendor_gpu_type)

--- a/aafd/property.te
+++ b/aafd/property.te
@@ -1,5 +1,4 @@
 type vendor_video_codec_prop, property_type;
 type vendor_hwcomposer_prop, property_type;
 type vendor_suspend, property_type;
-type vendor_gpu_type, property_type;
 type vendor_usb_controller_prop, property_type;

--- a/aafd/property_contexts
+++ b/aafd/property_contexts
@@ -3,5 +3,4 @@ vendor.hwcomposer.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.gralloc.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.egl.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.suspend u:object_r:vendor_suspend:s0
-vendor.gpu.type u:object_r:vendor_gpu_type:s0
 vendor.usb.controller u:object_r:vendor_usb_controller_prop:s0

--- a/aafd/vendor_init.te
+++ b/aafd/vendor_init.te
@@ -1,6 +1,5 @@
 set_prop(vendor_init, vendor_video_codec_prop)
 set_prop(vendor_init, vendor_suspend)
-set_prop(vendor_init, vendor_gpu_type)
 get_prop(vendor_init, vendor_hwcomposer_prop)
 set_prop(vendor_init, vendor_usb_controller_prop)
 

--- a/graphics/mesa/property_contexts
+++ b/graphics/mesa/property_contexts
@@ -1,2 +1,1 @@
-ro.graphics.hwcomposer.    u:object_r:vendor_graphics_hwcomposer_prop:s0
 vendor.hwcomposer.edid.    u:object_r:vendor_graphics_hwcomposer_prop:s0

--- a/thermal/property_contexts
+++ b/thermal/property_contexts
@@ -1,1 +1,2 @@
-persist.thermal.    u:object_r:vendor_thermal_prop:s0
+persist.vendor.thermal.    u:object_r:vendor_thermal_prop:s0
+vendor.thermal.            u:object_r:vendor_thermal_prop:s0


### PR DESCRIPTION
As persist.thermal and ro.graphics.hwcomposer properties are
vendor properties, vendor prefix is added to the property
names.

Tracked-On: OAM-94459
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>