### PR TITLE
Fix neverallow vendor violators

### DIFF
--- a/abota/generic/no_vendor_prefix/postinstall.te
+++ b/abota/generic/no_vendor_prefix/postinstall.te
@@ -1,4 +1,3 @@
 typeattribute postinstall system_writes_vendor_properties_violators;
-typeattribute postinstall system_executes_vendor_violators;
 set_prop(postinstall, ota_prop)
 

--- a/abota/generic/vendor_prefix/postinstall.te
+++ b/abota/generic/vendor_prefix/postinstall.te
@@ -1,3 +1,2 @@
 typeattribute postinstall system_writes_vendor_properties_violators;
-typeattribute postinstall system_executes_vendor_violators;
 set_prop(postinstall, vendor_ota_prop)


### PR DESCRIPTION
ATS test failure due to postinstall violating selinux neverallow rule.
Removed neverallow voilator rules.

Tracked-on: OAM-95348
Signed-off-by: rvuyyurx <Raja.NareshX.Vuyyuru@intel.com>
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>