### PR TITLE
provide rw permissions for sysfs

### DIFF
--- a/ethernet/common/genfs_contexts
+++ b/ethernet/common/genfs_contexts
@@ -1,3 +1,5 @@
 # /sys/class/net
 genfscon sysfs /devices/pci0000:00/0000:00:13.2/0000:03:00.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:13.1/0000:02:00.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:04.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/net u:object_r:sysfs_net:s0

--- a/ethernet/common/vendor_init.te
+++ b/ethernet/common/vendor_init.te
@@ -1,0 +1,1 @@
+allow vendor_init sysfs_net:file r_file_perms;


### PR DESCRIPTION
allow vendor_init permission for sysfs_net:file r_file_perms;
and update genfs_contexts as per adb shell ls -al /sys/class/net/
eth0 -> ../../devices/pci0000:00/0000:00:04.0/net
wlan0 -> ../../devices/pci0000:00/0000:00:07.0/net

Change-Id: I64b2eeac5cd313c1d84e29ae69dd3d80083bae56
Tracked-On: OAM-95354
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>