### PR TITLE
CIV: Gpu service rule added in sepolicy

### DIFF
--- a/vendor/gpusevice.te
+++ b/vendor/gpusevice.te
@@ -1,0 +1,3 @@
+#============= gpuservice ==============
+allow gpuservice gpu_device:dir { open read search };
+allow gpuservice sysfs_app_readable:file { open read };


### PR DESCRIPTION
Added gpu service rule to get Vulkan device
array list to pass GtsGraphicsHostTestCases

Change-Id: I837448a332f34efa4d69b7af6e324f4d8bfa9b36
Tracked-On: OAM-95361
Signed-off-by: vdanix <vishwanathx.dani@intel.com>
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>