### PR TITLE
sepolicy: Change role property to vendor namespace

### DIFF
--- a/usb-role-switch/property_contexts
+++ b/usb-role-switch/property_contexts
@@ -1,1 +1,1 @@
-persist.sys.usb.role u:object_r:vendor_usbrole_prop:s0
+vendor.sys.usb.role u:object_r:vendor_usbrole_prop:s0

--- a/usb-role-switch/system_app.te
+++ b/usb-role-switch/system_app.te
@@ -1,3 +1,0 @@
-typeattribute system_app system_writes_vendor_properties_violators;
-
-set_prop(system_app, vendor_usbrole_prop)


### PR DESCRIPTION
This patch changes 'persist.sys.usb.role' to
'vendor.sys.usb.role'. Also, now the system app
does not access this property anymore.
So, this patch removes the permission for
system app to access this property.

Change-Id: I4c4e21997b041b61af212aa05a7a19525206e050
Tracked-On: OAM-95380
Signed-off-by: saranya <saranya.gopal@intel.com>
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>