### PR TITLE
remove data_between_core_and_vendor_violators in mesa.

### DIFF
--- a/graphics/mesa/file.te
+++ b/graphics/mesa/file.te
@@ -21,3 +21,5 @@ typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;
 
 #coreu data/vendor permission
 type coreu_data_file, file_type, data_file_type;
+
+type hal_graphics_composer_rw_file, file_type;

--- a/graphics/mesa/hal_graphics_composer_default.te
+++ b/graphics/mesa/hal_graphics_composer_default.te
@@ -2,8 +2,8 @@ vndbinder_use(hal_graphics_composer_default)
 
 binder_call(hal_graphics_composer_default, hal_graphics_allocator_default)
 
-allow hal_graphics_composer_default cache_file:dir create_dir_perms;
-allow hal_graphics_composer_default cache_file:file create_file_perms;
+allow hal_graphics_composer_default hal_graphics_composer_rw_file:dir create_dir_perms;
+allow hal_graphics_composer_default hal_graphics_composer_rw_file:file create_file_perms;
 allow hal_graphics_composer_default gpu_device:chr_file rw_file_perms;
 allow hal_graphics_composer_default gpu_device:dir r_dir_perms;
 

--- a/graphics/mesa/vendor_init.te
+++ b/graphics/mesa/vendor_init.te
@@ -2,6 +2,5 @@ allow vendor_init self:capability { sys_module net_raw };
 allow vendor_init vendor_file:system module_load;
 allow vendor_init debugfs_tracing_instances:dir write;
 allow vendor_init mediaserver:process setsched;
-allow vendor_init system_data_file:dir create_dir_perms;
 allow vendor_init self:udp_socket create;
 allow vendor_init coreu_data_file:dir create_dir_perms;

--- a/graphics/mesa/violators_blacklist.te
+++ b/graphics/mesa/violators_blacklist.te
@@ -1,2 +1,0 @@
-typeattribute hal_graphics_composer_default data_between_core_and_vendor_violators;
-typeattribute vendor_init data_between_core_and_vendor_violators;


### PR DESCRIPTION
fix for TC failure:
com.google.android.security.gts.SELinuxHostTest

Change-Id: I26eb99ec3f4b06439ac67a1a55c3f3f3d3eefb27
Tracked-On: OAM-95469
Signed-off-by: Yuanzhe Liu <yuanzhe.liu@intel.com>
Reviewed-on: https://android.intel.com:443/679624
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>