### PR TITLE
delete vold and ueventd from data_between_core_and_vendor_violators

### DIFF
--- a/config-partition/ueventd.te
+++ b/config-partition/ueventd.te
@@ -1,6 +1,0 @@
-#
-# ueventd
-#
-
-allow ueventd config_file:dir search;
-allow ueventd config_file:file { read getattr open };

--- a/config-partition/violators_blacklist.te
+++ b/config-partition/violators_blacklist.te
@@ -1,3 +1,0 @@
-typeattribute vold data_between_core_and_vendor_violators;
-typeattribute ueventd data_between_core_and_vendor_violators;
-

--- a/config-partition/vold.te
+++ b/config-partition/vold.te
@@ -1,7 +1,0 @@
-#
-# vold
-#
-
-allow vold config_file:dir r_dir_perms;
-# uapi/linux/fs.h:#define FITRIM _IOWR('X', 121, struct fstrim_range) /* Trim */
-#allow vold config_file:dir 0x5879;


### PR DESCRIPTION
fix for TC failure:
com.google.android.security.gts.SELinuxHostTest#
testNoExemptionsForDataBetweenCoreAndVendor

Change-Id: Ie4d6c1a212fd7bb3b15cdd0b3a030f0b4afc8745
Tracked-On: OAM-95471
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
Reviewed-on: https://android.intel.com:443/679694
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>