### PR TITLE
Sepolicy changes for using Power HAL AIDL

### DIFF
--- a/power/service_contexts
+++ b/power/service_contexts
@@ -1,0 +1,1 @@
+android.hardware.power.IPower/default                                u:object_r:hal_power_service:s0


### PR DESCRIPTION
Add service_context file
Use domain tranfered label hal_power_default_exec for starting the
service

Tracked-On: OAM-95367
Signed-off-by: Shwetha B <shwetha.b@intel.com>