### PR TITLE
Rename dalvik_vm_isa_x86_variant_prop to vendor_dalvik_vm_isa_x86_var…

### DIFF
--- a/avx/checkavx.te
+++ b/avx/checkavx.te
@@ -10,8 +10,8 @@ allow checkavx vendor_file:file rx_file_perms;
 allow checkavx proc_cpuinfo:file r_file_perms;
 allow checkavx vendor_toolbox_exec:file execute_no_trans;
 
-set_prop(checkavx, dalvik_vm_isa_x86_variant_prop)
-set_prop(checkavx, dalvik_vm_isa_x86_64_variant_prop)
+set_prop(checkavx, vendor_dalvik_vm_isa_x86_variant_prop)
+set_prop(checkavx, vendor_dalvik_vm_isa_x86_64_variant_prop)
 
 not_full_treble(`
   allow checkavx system_file:file rx_file_perms;

--- a/avx/property.te
+++ b/avx/property.te
@@ -1,2 +1,2 @@
-type dalvik_vm_isa_x86_variant_prop, property_type; 
-type dalvik_vm_isa_x86_64_variant_prop, property_type; 
+type vendor_dalvik_vm_isa_x86_variant_prop, property_type; 
+type vendor_dalvik_vm_isa_x86_64_variant_prop, property_type; 

--- a/avx/property_contexts
+++ b/avx/property_contexts
@@ -1,2 +1,2 @@
-vendor.dalvik.vm.isa.x86.variant u:object_r:dalvik_vm_isa_x86_variant_prop:s0
-vendor.dalvik.vm.isa.x86_64.variant u:object_r:dalvik_vm_isa_x86_64_variant_prop:s0
+vendor.dalvik.vm.isa.x86.variant u:object_r:vendor_dalvik_vm_isa_x86_variant_prop:s0
+vendor.dalvik.vm.isa.x86_64.variant u:object_r:vendor_dalvik_vm_isa_x86_64_variant_prop:s0

--- a/avx/vendor_init.te
+++ b/avx/vendor_init.te
@@ -1,2 +1,2 @@
-set_prop(vendor_init, dalvik_vm_isa_x86_variant_prop)
-set_prop(vendor_init, dalvik_vm_isa_x86_64_variant_prop)
+set_prop(vendor_init, vendor_dalvik_vm_isa_x86_variant_prop)
+set_prop(vendor_init, vendor_dalvik_vm_isa_x86_64_variant_prop)


### PR DESCRIPTION
This patch renames 2 vendor properties to pass VTS.

Signed-off-by: svenate <salini.venate@intel.com>