### PR TITLE
Adding SELinux policy to fix CTS issue

### DIFF
--- a/vendor/dumpstate.te
+++ b/vendor/dumpstate.te
@@ -1,3 +1,5 @@
 dontaudit dumpstate sysfs:file read;
 dontaudit dumpstate device:file write;
 dontaudit dumpstate unlabeled:file read;
+allow dumpstate hal_power_default:binder call;
+allow dumpstate hal_light_default:binder call;


### PR DESCRIPTION
Added SEPolicy to allow hal_light_default and hal_power_default
binder calls

Signed-off-by: mbegumx <mogalx.begum@intel.com>