### PR TITLE
add right sepolicy for audio property

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -9,6 +9,7 @@ allow logwrapper self:bluetooth_socket create_socket_perms_no_ioctl;
 
 set_prop(logwrapper, vendor_graphics_hwcomposer_prop)
 set_prop(logwrapper, vendor_video_codec_prop)
+set_prop(logwrapper, vendor_audio_default_prop)
 
 set_prop(logwrapper, vendor_hwcomposer_prop)
 

--- a/audio/hal_audio_default.te
+++ b/audio/hal_audio_default.te
@@ -1,1 +1,1 @@
-get_prop(hal_audio_default, vendor_default_prop)
+get_prop(hal_audio_default, vendor_audio_default_prop)

--- a/audio/property.te
+++ b/audio/property.te
@@ -1,0 +1,1 @@
+type vendor_audio_default_prop, property_type;

--- a/audio/property_contexts
+++ b/audio/property_contexts
@@ -1,1 +1,1 @@
-ro.vendor.hdmi.audio    u:object_r:vendor_default_prop:s0
+ro.vendor.hdmi.audio    u:object_r:vendor_audio_default_prop:s0


### PR DESCRIPTION
audio ro.vendor.hdmi.audio is set with right
sepolicy

Tracked-On:OAM-95786
Signed-off-by: gkdeepa g.k.deepa@intel.com