### PR TITLE
Add aafd rule allow vold unmount for p9fs

### DIFF
--- a/aafd/vold.te
+++ b/aafd/vold.te
@@ -1,0 +1,1 @@
+allow vold p9fs:filesystem unmount;


### PR DESCRIPTION
Add aafd rule to allow vold umount of p9fs
to avoid kernel stall time on boot

Tracked-On: OAM-95904
Change-Id: I9bb68385b3eda2c4c8926bc9fa21a5602f66fde4
Signed-off-by: Swee Yee Fonn <swee.yee.fonn@intel.com>