### PR TITLE
sepolicy for setting fixed performance scale factor

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -14,6 +14,7 @@ set_prop(logwrapper, vendor_audio_default_prop)
 set_prop(logwrapper, vendor_hwcomposer_prop)
 
 set_prop(logwrapper, vendor_usb_controller_prop)
+set_prop(logwrapper, vendor_fixed_perf_prop)
 
 allow logwrapper p9fs:file r_file_perms;
 allow logwrapper p9fs:dir r_dir_perms;

--- a/aafd/property.te
+++ b/aafd/property.te
@@ -2,3 +2,4 @@ type vendor_video_codec_prop, property_type;
 type vendor_hwcomposer_prop, property_type;
 type vendor_suspend, property_type;
 type vendor_usb_controller_prop, property_type;
+type vendor_fixed_perf_prop, property_type;

--- a/aafd/property_contexts
+++ b/aafd/property_contexts
@@ -4,3 +4,4 @@ vendor.gralloc.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.egl.set u:object_r:vendor_hwcomposer_prop:s0
 vendor.suspend u:object_r:vendor_suspend:s0
 vendor.usb.controller u:object_r:vendor_usb_controller_prop:s0
+vendor.power.fixed_performance_scale_factor         u:object_r:vendor_fixed_perf_prop:s0

--- a/aafd/vendor_init.te
+++ b/aafd/vendor_init.te
@@ -2,6 +2,6 @@ set_prop(vendor_init, vendor_video_codec_prop)
 set_prop(vendor_init, vendor_suspend)
 get_prop(vendor_init, vendor_hwcomposer_prop)
 set_prop(vendor_init, vendor_usb_controller_prop)
-
+get_prop(vendor_init, vendor_fixed_perf_prop)
 #============= vendor_init ==============
 allow vendor_init tmpfs:dir { add_name create write };


### PR DESCRIPTION
adds sepolicy rules for setting the vendor property
vendor.power.fixed_performance_scale_factor which
in turn is used to set the system property
ro.power.fixed_performance_scale_factor

Tracked-On: OAM-95866
Signed-off-by: Shwetha B <shwetha.b@intel.com>