### PR TITLE
Remove un-used sepolicy for Virtio GPU

### DIFF
--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -22,7 +22,6 @@
 /(vendor|system/vendor)/lib(64)?/libskuwa\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.intel\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.celadon\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/hw/gralloc\.minigbm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libgrallocclient\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libglapi\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/i965_dri\.so u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
As we have rebased intel gralloc to Google minigbm
gralloc, so virtio_gpu.c file can support Virtio GPU
in intel gralloc too. Remove Google minigbm, and switch
to intel gralloc, which can also support gralloc HAL
1.0

Tracked-On: OAM-96513
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>