### PR TITLE
Make ServiceAgent app running in system app context

### DIFF
--- a/service.te
+++ b/service.te
@@ -1,0 +1,1 @@
+type serviceagent_service,          service_manager_type;

--- a/service_contexts
+++ b/service_contexts
@@ -1,0 +1,1 @@
+ServiceAgent                                   u:object_r:serviceagent_service:s0

--- a/system_app.te
+++ b/system_app.te
@@ -1,0 +1,4 @@
+add_service(system_app, serviceagent_service)
+
+#allow system_app kernel:binder { call transfer };
+binder_call(system_app, kernel);


### PR DESCRIPTION
ServiceAgent needs to be run in system app context for it retrieve
raw installed app information from Package Manager system service.

Change-Id: I752682007477806aa944ee4ffdf2094d0ded7c2b
Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Tracked-On: OAM-96944