### PR TITLE
Add the sepolicy for the vendor_graphics_gles and debugfs_graphics

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -4,6 +4,8 @@ allow logwrapper vendor_file:file rx_file_perms;
 allow logwrapper sysfs:file r_file_perms;
 allow logwrapper proc:file r_file_perms;
 allow logwrapper kernel:system module_request;
+allow logwrapper debugfs_graphics:file r_file_perms;
+allow logwrapper debugfs_graphics:dir r_dir_perms;
 
 allow logwrapper self:bluetooth_socket create_socket_perms_no_ioctl;
 
@@ -20,3 +22,4 @@ set_prop(logwrapper, vendor_fixed_perf_prop)
 allow logwrapper p9fs:file r_file_perms;
 allow logwrapper p9fs:dir r_dir_perms;
 set_prop(logwrapper, vendor_suspend_prop)
+set_prop(logwrapper, vendor_graphics_gles_prop)

--- a/graphics/mesa/genfs_contexts
+++ b/graphics/mesa/genfs_contexts
@@ -1,3 +1,4 @@
 genfscon proc /driver/i915rpm/i915_rpm_op u:object_r:proc_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:02.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:01.0/ u:object_r:sysfs_app_readable:s0
+genfscon debugfs /dri u:object_r:debugfs_graphics:s0

--- a/graphics/mesa/property.te
+++ b/graphics/mesa/property.te
@@ -1,1 +1,2 @@
 vendor_internal_prop(vendor_graphics_hwcomposer_prop)
+vendor_public_prop(vendor_graphics_gles_prop)

--- a/graphics/mesa/property_contexts
+++ b/graphics/mesa/property_contexts
@@ -1,1 +1,2 @@
 vendor.hwcomposer.edid.    u:object_r:vendor_graphics_hwcomposer_prop:s0
+vendor.gles.         u:object_r:vendor_graphics_gles_prop:s0

--- a/graphics/mesa/surfaceflinger.te
+++ b/graphics/mesa/surfaceflinger.te
@@ -26,3 +26,4 @@ allow surfaceflinger hal_graphics_composer_default:file { read getattr open };
 allow surfaceflinger gpu_device:dir r_dir_perms;
 allow surfaceflinger sysfs_app_readable:file r_file_perms;
 allow surfaceflinger self:process execmem;
+get_prop(surfaceflinger, vendor_graphics_gles_prop)


### PR DESCRIPTION
For the software rendering, need get the debugfs value and
set the gles property.

Tracked-On: OAM-97202
Signed-off-by: HeYue <yue.he@intel.com>
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>