### PR TITLE
Add right sepolicy for media_codecs property

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -23,3 +23,4 @@ allow logwrapper p9fs:file r_file_perms;
 allow logwrapper p9fs:dir r_dir_perms;
 set_prop(logwrapper, vendor_suspend_prop)
 set_prop(logwrapper, vendor_graphics_gles_prop)
+set_prop(logwrapper, vendor_media_target_prop)

--- a/aafd/vendor_init.te
+++ b/aafd/vendor_init.te
@@ -3,6 +3,7 @@ set_prop(vendor_init, vendor_suspend_prop)
 get_prop(vendor_init, vendor_hwcomposer_prop)
 set_prop(vendor_init, vendor_usb_controller_prop)
 get_prop(vendor_init, vendor_fixed_perf_prop)
+get_prop(vendor_init, vendor_media_target_prop)
 #============= vendor_init ==============
 allow vendor_init tmpfs:dir { add_name create write };
 set_prop(vendor_init, vendor_mount_ep0_prop)

--- a/codecs/property.te
+++ b/codecs/property.te
@@ -1,0 +1,1 @@
+vendor_internal_prop(vendor_media_target_prop)

--- a/codecs/property_contexts
+++ b/codecs/property_contexts
@@ -1,0 +1,1 @@
+ro.vendor.media.target_variant    u:object_r:vendor_media_target_prop:s0 prefix


### PR DESCRIPTION
ro.vendor.media.target_variant is set with right
sepolicy

Change-Id: Ibbac28b1d6dc6db59918dd3492262870553aff9d
Tracked-On: OAM-97743
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>