### PR TITLE
[TGL][VTS] x86 vts_ltp_test fix

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -1,0 +1,2 @@
+type proc_swappiness, proc_type, fs_type;
+type proc_disk_based_swap, proc_type, fs_type;

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -2,3 +2,5 @@
 genfscon sysfs /devices/pnp0/00:00/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:03/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:04/rtc   u:object_r:sysfs_rtc:s0
+genfscon proc  /sys/vm/swappiness        u:object_r:proc_swappiness:s0
+genfscon proc  /sys/vm/disk_based_swap   u:object_r:proc_disk_based_swap:s0

--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -2,3 +2,4 @@ allow vendor_init self:capability2 block_suspend;
 allow vendor_init kernel:system module_request;
 allow vendor_init debugfs_tracing_instances:dir create_dir_perms;
 allow vendor_init debugfs_tracing_instances:file w_file_perms;
+allow vendor_init proc:file write;

--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -2,4 +2,5 @@ allow vendor_init self:capability2 block_suspend;
 allow vendor_init kernel:system module_request;
 allow vendor_init debugfs_tracing_instances:dir create_dir_perms;
 allow vendor_init debugfs_tracing_instances:file w_file_perms;
-allow vendor_init proc:file write;
+allow vendor_init proc_swappiness:file w_file_perms;
+allow vendor_init proc_disk_based_swap:file w_file_perms;


### PR DESCRIPTION
[TGL][VTS] x86 vts_ltp_test_x86 test fix

The ltp test cases are failing because of the below selinux violations.

avc: denied { write } for comm="init" name="swappiness" dev="proc" ino=22697
scontext=u:r:vendor_init:s0 tcontext=u:object_r:proc:s0 tclass=file permissive=0

avc: denied { write } for comm="init" name="disk_based_swap" dev="proc"
ino=22698 scontext=u:r:vendor_init:s0 tcontext=u:object_r:proc:s0 tclass=file permissive=0

Added the permission to allow write for vendor_init.

Change-Id: Ibccae861f66715ea8c96ace406eff08e7e4a5bb6
Tracked-On: OAM-98169
Signed-off-by: vdanix <vishwanathx.dani@intel.com>