### PR TITLE
Add sepolicy for vsock socket.

### DIFF
--- a/clipboard_agent/private/system_app.te
+++ b/clipboard_agent/private/system_app.te
@@ -1,0 +1,1 @@
+allow system_app self:vsock_socket { create read write connect };


### PR DESCRIPTION
This is required to support clipboard
copy/paste feature.

Tracked-On: OAM-99249
Signed-off-by: ahs <amrita.h.s@intel.com>