### PR TITLE
add sepolicy rules for sensors user build

### DIFF
--- a/sensors/mediation/sensor_hal_default.te
+++ b/sensors/mediation/sensor_hal_default.te
@@ -2,9 +2,8 @@ allow hal_sensors_default self:socket create_socket_perms;
 allowxperm hal_sensors_default self:socket ioctl unpriv_sock_ioctls;
 allow hal_sensors_default serial_device:chr_file rw_file_perms;
 
-userdebug_or_eng(`
-    permissive hal_sensors_default;
-    dontaudit hal_sensors_default default_prop:file { open read getattr map };
-    dontaudit hal_sensors_default port:tcp_socket { name_connect };
-    dontaudit hal_sensors_default self:tcp_socket { create read write connect name_connect getopt setopt };
-')
+allow hal_sensors_default self:tcp_socket { create read write connect name_connect getopt setopt };
+dontaudit hal_sensors_default default_prop:file { open read getattr map };
+allow hal_sensors_default port:tcp_socket { name_connect };
+
+get_prop(hal_sensors_default, vendor_intel_ipaddr_prop)


### PR DESCRIPTION
CTS-verifier Device suspend activity test case for user build.

Tracked-On: OAM-99476
Signed-off-by: RajaniRanjan <rajani.ranjan@intel.com>