### PR TITLE
Add some sepolicy rules for Houdini

### DIFF
--- a/houdini/init.te
+++ b/houdini/init.te
@@ -1,0 +1,2 @@
+allow init proc:dir mounton;
+

--- a/houdini/vendor_init.te
+++ b/houdini/vendor_init.te
@@ -1,3 +1,5 @@
 set_prop(vendor_init, vendor_houdini_prop)
 set_prop(vendor_init, exported_dalvik_prop)
 
+allow vendor_init binfmt_miscfs:file write;
+allow vendor_init binfmt_miscfs:chr_file { create setattr unlink rw_file_perms };


### PR DESCRIPTION
Houdini will register some executable formats through the
special purpose file system binfmt_misc file-system interface.

Tracked-On: OAM-99548
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>