### PR TITLE
Add civ flag to load iwl700 driver only for civ

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -22,6 +22,7 @@ set_prop(logwrapper, vendor_fixed_perf_prop)
 allow logwrapper p9fs:file r_file_perms;
 allow logwrapper p9fs:dir r_dir_perms;
 set_prop(logwrapper, vendor_suspend_prop)
+set_prop(logwrapper, vendor_intel_wifi_iwl7000_prop)
 set_prop(logwrapper, vendor_intel_ipaddr_prop)
 set_prop(logwrapper, vendor_graphics_gles_prop)
 set_prop(logwrapper, vendor_media_target_prop)

--- a/aafd/vendor_init.te
+++ b/aafd/vendor_init.te
@@ -1,6 +1,7 @@
 set_prop(vendor_init, vendor_video_codec_prop)
 get_prop(appdomain, vendor_video_codec_prop)
 set_prop(vendor_init, vendor_suspend_prop)
+set_prop(vendor_init, vendor_intel_wifi_iwl7000_prop)
 set_prop(vendor_init, vendor_intel_ipaddr_prop)
 get_prop(vendor_init, vendor_hwcomposer_prop)
 set_prop(vendor_init, vendor_usb_controller_prop)

--- a/wlan/iwlwifi/property.te
+++ b/wlan/iwlwifi/property.te
@@ -1,1 +1,2 @@
 vendor_internal_prop(vendor_wifi_version_prop)
+vendor_internal_prop(vendor_intel_wifi_iwl7000_prop)

--- a/wlan/iwlwifi/property_contexts
+++ b/wlan/iwlwifi/property_contexts
@@ -1,2 +1,3 @@
 vendor.wlan.driver.version u:object_r:vendor_wifi_version_prop:s0
 vendor.wlan.firmware.version u:object_r:vendor_wifi_version_prop:s0
+vendor.intel.wifi_iwl7000 u:object_r:vendor_intel_wifi_iwl7000_prop:s0


### PR DESCRIPTION
Changes made to add new civ_target flag for conditional loading
of iwl7000 driver.

Tracked-On: OAM-99828
Signed-off-by: Bharat B Panda <bharat.b.panda@intel.com>