### PR TITLE
Moving Thermal Related SEPolicy

### DIFF
--- a/aafd/aafd.te
+++ b/aafd/aafd.te
@@ -24,8 +24,6 @@ allow aafd sysfs_net:dir r_dir_perms;
 allow aafd sysfs_net:file w_file_perms;
 allow aafd sysfs_rtc:dir r_dir_perms;
 allow aafd sysfs_rtc:file w_file_perms;
-allow aafd sysfs_thermal_management:dir r_dir_perms;
-allow aafd sysfs_thermal_management:file w_file_perms;
 allow aafd sysfs_zram:dir r_dir_perms;
 allow aafd sysfs_zram_uevent:file w_file_perms;
 allow aafd vendor_file:system module_load;

--- a/light/hal_light_default.te
+++ b/light/hal_light_default.te
@@ -1,3 +1,2 @@
 # allow hal_light_default set brightness for light module
 allow hal_light_default sysfs_backlight:file rw_file_perms;
-allow hal_light_default sysfs_backlight_thermal:dir search;

--- a/thermal/thermal-daemon/thermal-daemon.te
+++ b/thermal/thermal-daemon/thermal-daemon.te
@@ -34,6 +34,10 @@ allow thermal-daemon thermal_device:chr_file rw_file_perms;
 allow thermal-daemon self:netlink_kobject_uevent_socket create_socket_perms;
 allowxperm thermal-daemon self:netlink_kobject_uevent_socket ioctl SIOCETHTOOL;
 allow thermal-daemon vendor_file:dir read;
+allow hal_light_default sysfs_backlight_thermal:dir search;
+allow recovery sysfs_backlight_thermal:dir  search;
+allow aafd sysfs_thermal_management:dir r_dir_perms;
+allow aafd sysfs_thermal_management:file w_file_perms;
 
 # properties
 set_prop(thermal-daemon, powerctl_prop)

--- a/vendor/recovery.te
+++ b/vendor/recovery.te
@@ -1,4 +1,3 @@
 recovery_only(`
   allow recovery gpu_device:dir  search;
-  allow recovery sysfs_backlight_thermal:dir  search;
 ')


### PR DESCRIPTION
When Thermal Daemon is disabled from mixins
due to unavilablity of resepective thermal
sepolicy thermal types we get compilation
issues to avoid this we need to move thermal
policy in respective thermal files.

Tracked-On:
Signed-off-by: vilasrk <vilas.r.k@intel.com>