### PR TITLE
Allow wechat to access 9p share folder

### DIFF
--- a/aafd/file.te
+++ b/aafd/file.te
@@ -1,1 +1,0 @@
-type p9fs2, fs_type, mlstrustedobject;

--- a/aafd/genfs_contexts
+++ b/aafd/genfs_contexts
@@ -1,2 +1,1 @@
-genfscon 9p / u:object_r:p9fs2:s0
 genfscon sysfs /class/udc u:object_r:sysfs_usb:s0

--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -25,6 +25,8 @@ allow logwrapper p9fs2:dir r_dir_perms;
 allow platform_app p9fs2:file r_file_perms;
 allow platform_app p9fs2:dir r_dir_perms;
 allow untrusted_app_29 p9fs2:file r_file_perms;
+allow untrusted_app_29 p9fs2:file create_file_perms;
+allow untrusted_app_29 p9fs2:dir rw_dir_perms;
 
 set_prop(logwrapper, vendor_suspend_prop)
 set_prop(logwrapper, vendor_intel_ipaddr_prop)


### PR DESCRIPTION
Fix the issue that wechat can not read files in host sharefolder

Tracked-On: OAM-100644
Signed-off-by: Ai, Ting <ting.a.ai@intel.com>