### PR TITLE
for AOSP S (12.0) Houdini Sepolicy

### DIFF
--- a/houdini/shell.te
+++ b/houdini/shell.te
@@ -2,3 +2,5 @@ allow shell same_process_hal_file:file rx_file_perms;
 allowxperm shell self:fifo_file ioctl TIOCGPTN;
 
 get_prop(shell, vendor_houdini_default_prop)
+allow shell vendor_file:file { read execute map open getattr execute_no_trans };
+


### PR DESCRIPTION
Add in shell.te "allow shell vendor_file:file {xxx}"
Tracked-On: OAM-100728
Signed-off-by: danielphs <hongsheng.peng@intel.com>