### PR TITLE
Sensors Availabity on HOST Machine

### DIFF
--- a/sensors/mediation/property.te
+++ b/sensors/mediation/property.te
@@ -1,1 +1,2 @@
 vendor_internal_prop(vendor_intel_ipaddr_prop)
+vendor_internal_prop(vendor_intel_sensors_available_prop)

--- a/sensors/mediation/property_contexts
+++ b/sensors/mediation/property_contexts
@@ -1,1 +1,2 @@
 vendor.intel.ipaddr u:object_r:vendor_intel_ipaddr_prop:s0
+vendor.intel.sensors_available u:object_r:vendor_intel_sensors_available_prop:s0

--- a/sensors/mediation/sensor_hal_default.te
+++ b/sensors/mediation/sensor_hal_default.te
@@ -9,3 +9,4 @@ dontaudit hal_sensors_default default_prop:file { open read getattr map };
 allow hal_sensors_default port:tcp_socket { name_connect };
 
 get_prop(hal_sensors_default, vendor_intel_ipaddr_prop)
+get_prop(hal_sensors_default, vendor_intel_sensors_available_prop)


### PR DESCRIPTION
Allow Sensor HAL to read property
which indicates presence of Sensors on
HOST Machine

Signed-off-by: Vilas R K <vilas.r.k@intel.com>