### PR TITLE
Update sepolicy for vsock_socket.

### DIFF
--- a/clipboard_agent/private/system_app.te
+++ b/clipboard_agent/private/system_app.te
@@ -1,1 +1,1 @@
-allow system_app self:vsock_socket { create read write connect };
+allow system_app self:vsock_socket { create read write connect accept bind};


### PR DESCRIPTION
accept and bind permissions are required to
implement guest-host comminication usecases
using gRPC framework.

Tracked-On:
Signed-off-by: ahs <amrita.h.s@intel.com>