### PR TITLE
Keep separate type/context for aafd

### DIFF
--- a/aafd/file.te
+++ b/aafd/file.te
@@ -1,1 +1,1 @@
-type p9fs, fs_type, mlstrustedobject;
+type p9fs2, fs_type, mlstrustedobject;

--- a/aafd/genfs_contexts
+++ b/aafd/genfs_contexts
@@ -1,2 +1,2 @@
-genfscon 9p / u:object_r:p9fs:s0
+genfscon 9p / u:object_r:p9fs2:s0
 genfscon sysfs /class/udc u:object_r:sysfs_usb:s0

--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -19,8 +19,8 @@ set_prop(logwrapper, vendor_hwcomposer_prop)
 set_prop(logwrapper, vendor_usb_controller_prop)
 set_prop(logwrapper, vendor_fixed_perf_prop)
 
-allow logwrapper p9fs:file r_file_perms;
-allow logwrapper p9fs:dir r_dir_perms;
+allow logwrapper p9fs2:file r_file_perms;
+allow logwrapper p9fs2:dir r_dir_perms;
 set_prop(logwrapper, vendor_suspend_prop)
 set_prop(logwrapper, vendor_intel_ipaddr_prop)
 set_prop(logwrapper, vendor_graphics_gles_prop)


### PR DESCRIPTION
Fix for AAFD folder not auto mounted at boot and suspend detection fails

Tracked-On: OAM-102731
Signed-off-by: Suresh, Prashanth <prashanth.suresh@intel.com>