### PR TITLE
Add vulkan pastel for mesa 22.0.3

### DIFF
--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -29,6 +29,7 @@
 /(vendor|system/vendor)/lib(64)?/dri/virtio_gpu_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/gallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/vulkan\.intel\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/hw/vulkan\.pastel\.so  u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/libgallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libmd\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/egl/libEGL_swiftshader\.so u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
Fix for CtsDeqpTestCases in user build
Tests are filing with :
avc: denied { read } for name="vulkan.pastel.so"

Most of below tests are failing.
dEQP-VK.info.*
dEQP-VK.api.*

Tracked-On: OAM-103857
Signed-off-by: vdanix <vishwanathx.dani@intel.com>