### PR TITLE
Add missing nodes for rw in sepolicy

### DIFF
--- a/ethernet/common/genfs_contexts
+++ b/ethernet/common/genfs_contexts
@@ -4,3 +4,5 @@ genfscon sysfs /devices/pci0000:00/0000:00:13.1/0000:02:00.0/net u:object_r:sysf
 genfscon sysfs /devices/pci0000:00/0000:00:04.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:07.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:06.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:09.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:0a.0/net u:object_r:sysfs_net:s0


### PR DESCRIPTION
Fix the VTS with adding missing nodes for
/sys/*/net

Tracked-On: OAM-103863
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>