### PR TITLE
CtsOsTestCases ro.vndk.version should be comared with Build.VERSION_C…

### DIFF
--- a/soc/file_contexts
+++ b/soc/file_contexts
@@ -1,0 +1,1 @@
+(/system)?/vendor/bin/set_soc_prop.sh u:object_r:set_soc_prop_exec:s0

--- a/soc/property.te
+++ b/soc/property.te
@@ -1,0 +1,1 @@
+vendor_internal_prop(vendor_cpu_model_name_prop)

--- a/soc/property_contexts
+++ b/soc/property_contexts
@@ -1,0 +1,1 @@
+vendor.cpu.model_name u:object_r:vendor_cpu_model_name_prop:s0

--- a/soc/set_soc_prop.te
+++ b/soc/set_soc_prop.te
@@ -1,0 +1,18 @@
+# Rules for soc
+type set_soc_prop, domain;
+type set_soc_prop_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(set_soc_prop)
+
+allow set_soc_prop proc_cpuinfo:file r_file_perms;
+allow set_soc_prop vendor_toolbox_exec:file execute_no_trans;
+
+set_prop(set_soc_prop, vendor_cpu_model_name_prop)
+
+not_full_treble(`
+  allow set_soc_prop system_file:file rx_file_perms;
+  allow set_soc_prop shell_exec:file rx_file_perms;
+')
+full_treble_only(`
+  allow set_soc_prop vendor_shell_exec:file rx_file_perms;
+  allow set_soc_prop vendor_toolbox_exec:file rx_file_perms;
+')

--- a/soc/shell.te
+++ b/soc/shell.te
@@ -1,0 +1,1 @@
+allow shell set_soc_prop_exec:file getattr;

--- a/soc/vendor_init.te
+++ b/soc/vendor_init.te
@@ -1,0 +1,1 @@
+set_prop(vendor_init, vendor_cpu_model_name_prop)


### PR DESCRIPTION
…ODES.S instead of Build.VERSION_CODES.R in CTS

Following CTS test android.os.cts.BuildTest#testBuildConstants is failing due to missing SoC properties. A12 onwards, Below SoC properties need to define to pass CTS test-:
ro.soc.manufacturer
ro.soc.model

Tracked-On: OAM-103794
Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>