### PR TITLE
Remove debugfs related sepolicy rules

### DIFF
--- a/debug-phonedoctor/crashreport_app.te
+++ b/debug-phonedoctor/crashreport_app.te
@@ -14,7 +14,6 @@ userdebug_or_eng(`
   allow crashreport_app crashreport_app_data_file:dir create_dir_perms;
   allow crashreport_app crashreport_app_data_file:file create_file_perms;
   allow crashreport_app crashreport_app_data_file:file r_file_perms;
-  allow crashreport_app debugfs:dir r_dir_perms;
   allow crashreport_app init:unix_stream_socket connectto;
   allow crashreport_app log_file:dir create_dir_perms;
   allow crashreport_app log_file:file create_file_perms;

--- a/debugfs/dumpstate.te
+++ b/debugfs/dumpstate.te
@@ -1,5 +1,0 @@
-#
-# dumpstate
-#
-
-dontaudit dumpstate debugfs_graphics_sync:file r_file_perms;

--- a/debugfs/file.te
+++ b/debugfs/file.te
@@ -1,2 +1,0 @@
-# debugfs sync file
-type debugfs_graphics_sync, fs_type, debugfs_type;

--- a/debugfs/file_contexts
+++ b/debugfs/file_contexts
@@ -1,1 +1,0 @@
-/sys/kernel/debug/sync      u:object_r:debugfs_graphics_sync:s0

--- a/debugfs/platform_app.te
+++ b/debugfs/platform_app.te
@@ -1,5 +1,0 @@
-#
-# platform_app
-#
-
-allow platform_app debugfs_graphics_sync:file r_file_perms;

--- a/graphics/mesa/dumpstate.te
+++ b/graphics/mesa/dumpstate.te
@@ -1,4 +1,2 @@
 dontaudit dumpstate graphics_device:dir search;
-allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
-allow dumpstate debugfs_mmc:dir r_dir_perms;
 allow dumpstate sysfs_zram:dir r_dir_perms;

--- a/graphics/mesa_acrn/dumpstate.te
+++ b/graphics/mesa_acrn/dumpstate.te
@@ -1,4 +1,2 @@
 dontaudit dumpstate graphics_device:dir search;
-allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
-allow dumpstate debugfs_mmc:dir r_dir_perms;
 allow dumpstate sysfs_zram:dir r_dir_perms;

--- a/graphics/mesa_acrn/file.te
+++ b/graphics/mesa_acrn/file.te
@@ -15,8 +15,6 @@ type sysfs_videostatus, fs_type, sysfs_type;
 # i915 related /proc/driver entry.
 type proc_graphics, fs_type, proc_type;
 
-type debugfs_graphics, fs_type, debugfs_type;
-
 type sysfs_app_readable, fs_type, sysfs_type;
 
 typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;

--- a/graphics/mesa_xen/dumpstate.te
+++ b/graphics/mesa_xen/dumpstate.te
@@ -1,4 +1,2 @@
 dontaudit dumpstate graphics_device:dir search;
-allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
-allow dumpstate debugfs_mmc:dir r_dir_perms;
 allow dumpstate sysfs_zram:dir r_dir_perms;

--- a/graphics/mesa_xen/file.te
+++ b/graphics/mesa_xen/file.te
@@ -16,8 +16,6 @@ type sysfs_videostatus, fs_type, sysfs_type;
 # i915 related /proc/driver entry.
 type proc_graphics, fs_type, proc_type;
 
-type debugfs_graphics, fs_type, debugfs_type;
-
 type sysfs_app_readable, fs_type, sysfs_type;
 
 typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;

--- a/graphics/mesa_xen/file_contexts
+++ b/graphics/mesa_xen/file_contexts
@@ -20,8 +20,6 @@
 # i915 videostatus
 /sys/devices/pci0000:00/0000:00:02.0/drm/card0/power/i915_videostatus u:object_r:sysfs_videostatus:s0
 
-/sys/kernel/debug/dri/0/i915_frequency_info u:object_r:debugfs_graphics:s0
-
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0

--- a/graphics/ufo_common/coreu.te
+++ b/graphics/ufo_common/coreu.te
@@ -59,9 +59,5 @@ allow coreu sysfs_gfx:file rw_file_perms;
 
 allow coreu proc_graphics:file r_file_perms;
 
-#debugfs
-allow coreu debugfs_tracing:file rw_file_perms;
-allow coreu debugfs_graphics:file rw_file_perms;
-
 # drm detecting
 allow coreu mediadrmserver:process signull;

--- a/graphics/ufo_common/file.te
+++ b/graphics/ufo_common/file.te
@@ -17,8 +17,6 @@ type sysfs_videostatus, fs_type, sysfs_type;
 # i915 related /proc/driver entry.
 type proc_graphics, fs_type, proc_type;
 
-type debugfs_graphics, fs_type, debugfs_type;
-
 type sysfs_app_readable, fs_type, sysfs_type;
 
 typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;

--- a/graphics/ufo_common/file_contexts
+++ b/graphics/ufo_common/file_contexts
@@ -15,8 +15,6 @@
 # i915 videostatus
 /sys/devices/pci0000:00/0000:00:02.0/drm/card0/power/i915_videostatus u:object_r:sysfs_videostatus:s0
 
-/sys/kernel/debug/dri/0/i915_frequency_info u:object_r:debugfs_graphics:s0
-
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0

--- a/kernel/file.te
+++ b/kernel/file.te
@@ -1,1 +1,0 @@
-type debugfs_pstate, fs_type, debugfs_type;

--- a/kernel/file_contexts
+++ b/kernel/file_contexts
@@ -1,1 +1,0 @@
-/sys/kernel/debug/pstate_snb/setpoint u:object_r:debugfs_pstate:s0

--- a/kernel/init.te
+++ b/kernel/init.te
@@ -2,12 +2,6 @@
 # init
 #
 
-# mixin kernel/init.rc write to /sys/kernel/debug/pstate_snb/setpoint
-allow init debugfs_pstate:file w_file_perms;
-
-#avc: denied { write } for pid=1 comm="init" name="psys_force_freq" dev="debugfs" ino=8600 scontext=u:r:init:s0 tcontext=u:object_r:debugfs:s0 tclass=file permissive=0
-allow init debugfs:file write;
-
 # allow init insmod keyword
 allow init kernel:key search;
 allow init {

--- a/kernel/kernel.te
+++ b/kernel/kernel.te
@@ -12,6 +12,3 @@ allow kernel kernel:capability sys_admin;
 # For loading /lib/modules/inet_diag.ko
 allow kernel rootfs:system module_load;
 allow kernel system_file:system module_load;
-
-# For adding mmc debugfs directory in the runtime
-allow kernel debugfs_mmc:dir search;

--- a/vendor/ueventd.te
+++ b/vendor/ueventd.te
@@ -1,1 +1,0 @@
-allow ueventd debugfs_wakeup_sources:file r_file_perms;


### PR DESCRIPTION
Google doesn't allow vendors to use debugfs in the user build
from android 12, and they add checks in some CTS test cases.
So the sepolicy rules related debugfs in celadon should be
removed.

Tracked-On: OAM-104124
Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>