### PR TITLE
Add Trusty metadata sepolicy

### DIFF
--- a/trusty/enabled/tee.te
+++ b/trusty/enabled/tee.te
@@ -11,3 +11,5 @@ allow tee rpmb_virt_device:chr_file { open read write };
 allow tee self:capability sys_rawio;
 allow tee block_device:dir search;
 allow tee tee_device:blk_file rw_file_perms;
+allow tee gsi_metadata_file:dir search;
+allow tee metadata_file:dir search;


### PR DESCRIPTION
Android storageproxyd service failed to launch due to metadata accessed denied by sepolicy on BM with Android T.

Update sepolicy to allow TEE accessing metadata to address this issue.

Tracked-On: OAM-104065
Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>