### PR TITLE
[s/stable] Remove debugfs_graphics related sepolicy rules

### DIFF
--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -4,8 +4,6 @@ allow logwrapper vendor_file:file rx_file_perms;
 allow logwrapper sysfs:file r_file_perms;
 allow logwrapper proc:file r_file_perms;
 allow logwrapper kernel:system module_request;
-allow logwrapper debugfs_graphics:file r_file_perms;
-allow logwrapper debugfs_graphics:dir r_dir_perms;
 
 allow logwrapper self:bluetooth_socket create_socket_perms_no_ioctl;
 

--- a/graphics/mesa/coreu.te
+++ b/graphics/mesa/coreu.te
@@ -52,7 +52,6 @@ allow coreu proc_graphics:file r_file_perms;
 
 #debugfs
 allow coreu debugfs_tracing:file rw_file_perms;
-allow coreu debugfs_graphics:file rw_file_perms;
 
 # drm detecting
 allow coreu mediadrmserver:process signull;

--- a/graphics/mesa/file.te
+++ b/graphics/mesa/file.te
@@ -13,8 +13,6 @@ type sysfs_videostatus, fs_type, sysfs_type;
 # i915 related /proc/driver entry.
 type proc_graphics, fs_type, proc_type;
 
-type debugfs_graphics, fs_type, debugfs_type;
-
 type sysfs_app_readable, fs_type, sysfs_type;
 
 typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;

--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -13,8 +13,6 @@
 # i915 videostatus
 /sys/devices/pci0000:00/0000:00:02.0/drm/card0/power/i915_videostatus u:object_r:sysfs_videostatus:s0
 
-/sys/kernel/debug/dri/0/i915_frequency_info u:object_r:debugfs_graphics:s0
-
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0

--- a/graphics/mesa/genfs_contexts
+++ b/graphics/mesa/genfs_contexts
@@ -1,5 +1,4 @@
 genfscon proc /driver/i915rpm/i915_rpm_op u:object_r:proc_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:02.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:01.0/ u:object_r:sysfs_app_readable:s0
-genfscon debugfs /dri u:object_r:debugfs_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:03.0/ u:object_r:sysfs_app_readable:s0

--- a/graphics/mesa_acrn/file_contexts
+++ b/graphics/mesa_acrn/file_contexts
@@ -11,8 +11,6 @@
 # i915 videostatus
 /sys/devices/pci0000:00/0000:00:02.0/drm/card0/power/i915_videostatus u:object_r:sysfs_videostatus:s0
 
-/sys/kernel/debug/dri/0/i915_frequency_info u:object_r:debugfs_graphics:s0
-
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
Removed the sepolicy rules related debugfs_graphics in Celadon as Google does not allow vendors to use debugfs_graphics in user build from android 12 by CTS test.

Tracked-On: OAM-104060
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>