### PR TITLE
Added sepolicy for GPU access in dumpstate tool

### DIFF
--- a/vendor/dumpstate.te
+++ b/vendor/dumpstate.te
@@ -3,3 +3,4 @@ dontaudit dumpstate device:file write;
 dontaudit dumpstate unlabeled:file read;
 allow dumpstate hal_power_default:binder call;
 allow dumpstate hal_light_default:binder call;
+allow dumpstate gpu_device:dir r_dir_perms;


### PR DESCRIPTION
Added permission to access GPU from dumpstate tool that invokes screencap to take screenshot.

Tracked-On: OAM-104941
Signed-off-by: Vasoya,Nikhilx <nikhilx.vasoya@intel.com>