### PR TITLE
Remove HDCP from sepolicy

### DIFF
--- a/graphics/mesa/hdcpd.te
+++ b/graphics/mesa/hdcpd.te
@@ -1,3 +1,0 @@
-allow hdcpd proc_graphics:file r_file_perms;
-binder_call(hdcpd, hal_graphics_composer_default);
-

--- a/graphics/mesa/msync.te
+++ b/graphics/mesa/msync.te
@@ -10,4 +10,3 @@ not_full_treble(`
 ')
 add_service(msync, msync_service)
 binder_call(msync, coreu)
-binder_call(msync, hdcpd)


### PR DESCRIPTION
HDCP is depent on ia-hwc. since ia-hwc is not used. Has to remove HDCP to avoid compiling error

Tracked-On: OAM-105293
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>