### PR TITLE
Enable sw rendering.

### DIFF
--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -31,9 +31,7 @@
 /(vendor|system/vendor)/lib(64)?/hw/vulkan\.intel\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/libgallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libmd\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/egl/libEGL_swiftshader\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/egl/libGLESv1_CM_swiftshader\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/egl/libGLESv2_swiftshader\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/hw/vulkan\.pastel\.so u:object_r:same_process_hal_file:s0
 
 #coreu /data/vendor permission
 /data/vendor/coreu(/.*)?       u:object_r:coreu_data_file:s0


### PR DESCRIPTION
SwiftShader's GL libraries are getting deprecated in andriod T, and to be replaced with ANGLE on top of SwiftShader's Vulkan library.

Add vulkan.pastel.so in file_contexts

Tracked-On: OAM-104193