### PR TITLE
Sepolicy fix

### DIFF
--- a/.github/workflows/run_ci_checks.yaml
+++ b/.github/workflows/run_ci_checks.yaml
@@ -1,0 +1,15 @@
+---
+name: Run CI checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: "**"
+  pull_request_review:
+    types: [submitted]
+    branches: "**"
+jobs:
+  TriggerWorkfows:
+    uses: projectceladon/celadonworkflows/.github/workflows/trigger_ci.yml@v1.0
+    with:
+      EVENT: ${{ toJSON(github.event) }}

--- a/0001-Fix-EVS-sample-driver-not-getting-started-as-service.patch
+++ b/0001-Fix-EVS-sample-driver-not-getting-started-as-service.patch
@@ -1,0 +1,46 @@
+From ae58b9cd6771e2c7673f98ab5507ff97f47e70bb Mon Sep 17 00:00:00 2001
+From: "Pillai, Venkatesh" <venkatesh.pillai@intel.com>
+Date: Fri, 21 Apr 2023 14:20:06 +0530
+Subject: [PATCH] Fix EVS sample driver not getting started as service
+
+EVS sample driver not getting started as service due to missing
+sepolicies
+
+Changes done to fix the issue:
+- Allow carservice_app with service find rights
+- Allow carservice_app with open, read and search access for sysfs dir
+- Allow carservice_app with search access for data folder
+
+Tracked-On: OAM-108929
+Signed-off-by: Pillai, Venkatesh <venkatesh.pillai@intel.com>
+---
+ camera-ext/ext-camera-only/file_contexts | 1 +
+ car/carservice_app.te                    | 5 +++++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/camera-ext/ext-camera-only/file_contexts b/camera-ext/ext-camera-only/file_contexts
+index 31d7ef4..4c93e38 100644
+--- a/camera-ext/ext-camera-only/file_contexts
++++ b/camera-ext/ext-camera-only/file_contexts
+@@ -1 +1,2 @@
+ /dev/media[0-9]+          u:object_r:video_device:s0
++/(vendor|system/vendor)/bin/android\.hardware\.automotive\.evs@1\.[0-9]-sample  u:object_r:hal_evs_default_exec:s0
+diff --git a/car/carservice_app.te b/car/carservice_app.te
+index e542443..f69eb06 100644
+--- a/car/carservice_app.te
++++ b/car/carservice_app.te
+@@ -1,6 +1,11 @@
+ allow carservice_app sysfs:dir r_dir_perms;
+ allow carservice_app sysfs_fs_f2fs:dir r_dir_perms;
+ allow carservice_app sysfs_fs_ext4_features:dir r_dir_perms;
++allow carservice_app system_data_file:dir search;
++allow carservice_app user_profile_root_file:dir search;
++allow carservice_app content_capture_service:service_manager find;
++allow carservice_app game_service:service_manager find;
++allow carservice_app media_communication_service:service_manager find;
+ 
+ # To allow carservice app to  access sys.usb.cfg
+ module_only(`carservice_app', `
+-- 
+2.17.1
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,176 @@
+Apache License
+                           Version 2.0, January 2022
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -4,8 +4,6 @@ allow logwrapper vendor_file:file rx_file_perms;
 allow logwrapper sysfs:file r_file_perms;
 allow logwrapper proc:file r_file_perms;
 allow logwrapper kernel:system module_request;
-allow logwrapper debugfs_graphics:file r_file_perms;
-allow logwrapper debugfs_graphics:dir r_dir_perms;
 
 allow logwrapper self:bluetooth_socket create_socket_perms_no_ioctl;
 

--- a/debug-phonedoctor/crashreport_app.te
+++ b/debug-phonedoctor/crashreport_app.te
@@ -14,7 +14,6 @@ userdebug_or_eng(`
   allow crashreport_app crashreport_app_data_file:dir create_dir_perms;
   allow crashreport_app crashreport_app_data_file:file create_file_perms;
   allow crashreport_app crashreport_app_data_file:file r_file_perms;
-  allow crashreport_app debugfs:dir r_dir_perms;
   allow crashreport_app init:unix_stream_socket connectto;
   allow crashreport_app log_file:dir create_dir_perms;
   allow crashreport_app log_file:file create_file_perms;

--- a/debugfs/dumpstate.te
+++ b/debugfs/dumpstate.te
@@ -1,5 +1,0 @@
-#
-# dumpstate
-#
-
-dontaudit dumpstate debugfs_graphics_sync:file r_file_perms;

--- a/debugfs/file.te
+++ b/debugfs/file.te
@@ -1,2 +1,0 @@
-# debugfs sync file
-type debugfs_graphics_sync, fs_type, debugfs_type;

--- a/debugfs/file_contexts
+++ b/debugfs/file_contexts
@@ -1,1 +1,0 @@
-/sys/kernel/debug/sync      u:object_r:debugfs_graphics_sync:s0

--- a/debugfs/platform_app.te
+++ b/debugfs/platform_app.te
@@ -1,5 +1,0 @@
-#
-# platform_app
-#
-
-allow platform_app debugfs_graphics_sync:file r_file_perms;

--- a/ethernet/common/genfs_contexts
+++ b/ethernet/common/genfs_contexts
@@ -4,3 +4,5 @@ genfscon sysfs /devices/pci0000:00/0000:00:13.1/0000:02:00.0/net u:object_r:sysf
 genfscon sysfs /devices/pci0000:00/0000:00:04.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:07.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:06.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:09.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:0a.0/net u:object_r:sysfs_net:s0

--- a/graphics/mesa/coreu.te
+++ b/graphics/mesa/coreu.te
@@ -52,7 +52,6 @@ allow coreu proc_graphics:file r_file_perms;
 
 #debugfs
 allow coreu debugfs_tracing:file rw_file_perms;
-allow coreu debugfs_graphics:file rw_file_perms;
 
 # drm detecting
 allow coreu mediadrmserver:process signull;

--- a/graphics/mesa/dumpstate.te
+++ b/graphics/mesa/dumpstate.te
@@ -1,4 +1,2 @@
 dontaudit dumpstate graphics_device:dir search;
-allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
-allow dumpstate debugfs_mmc:dir r_dir_perms;
 allow dumpstate sysfs_zram:dir r_dir_perms;

--- a/graphics/mesa/file.te
+++ b/graphics/mesa/file.te
@@ -13,8 +13,6 @@ type sysfs_videostatus, fs_type, sysfs_type;
 # i915 related /proc/driver entry.
 type proc_graphics, fs_type, proc_type;
 
-type debugfs_graphics, fs_type, debugfs_type;
-
 type sysfs_app_readable, fs_type, sysfs_type;
 
 typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;

--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -13,8 +13,6 @@
 # i915 videostatus
 /sys/devices/pci0000:00/0000:00:02.0/drm/card0/power/i915_videostatus u:object_r:sysfs_videostatus:s0
 
-/sys/kernel/debug/dri/0/i915_frequency_info u:object_r:debugfs_graphics:s0
-
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0

--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -29,6 +29,7 @@
 /(vendor|system/vendor)/lib(64)?/dri/virtio_gpu_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/gallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/vulkan\.intel\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/hw/vulkan\.pastel\.so  u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/libgallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libmd\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/egl/libEGL_swiftshader\.so u:object_r:same_process_hal_file:s0

--- a/graphics/mesa/genfs_contexts
+++ b/graphics/mesa/genfs_contexts
@@ -1,5 +1,4 @@
 genfscon proc /driver/i915rpm/i915_rpm_op u:object_r:proc_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:02.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:01.0/ u:object_r:sysfs_app_readable:s0
-genfscon debugfs /dri u:object_r:debugfs_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:03.0/ u:object_r:sysfs_app_readable:s0

--- a/graphics/mesa_acrn/dumpstate.te
+++ b/graphics/mesa_acrn/dumpstate.te
@@ -1,4 +1,2 @@
 dontaudit dumpstate graphics_device:dir search;
-allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
-allow dumpstate debugfs_mmc:dir r_dir_perms;
 allow dumpstate sysfs_zram:dir r_dir_perms;

--- a/graphics/mesa_acrn/file.te
+++ b/graphics/mesa_acrn/file.te
@@ -15,8 +15,6 @@ type sysfs_videostatus, fs_type, sysfs_type;
 # i915 related /proc/driver entry.
 type proc_graphics, fs_type, proc_type;
 
-type debugfs_graphics, fs_type, debugfs_type;
-
 type sysfs_app_readable, fs_type, sysfs_type;
 
 typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;

--- a/graphics/mesa_acrn/file_contexts
+++ b/graphics/mesa_acrn/file_contexts
@@ -11,8 +11,6 @@
 # i915 videostatus
 /sys/devices/pci0000:00/0000:00:02.0/drm/card0/power/i915_videostatus u:object_r:sysfs_videostatus:s0
 
-/sys/kernel/debug/dri/0/i915_frequency_info u:object_r:debugfs_graphics:s0
-
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0

--- a/graphics/mesa_xen/dumpstate.te
+++ b/graphics/mesa_xen/dumpstate.te
@@ -1,4 +1,2 @@
 dontaudit dumpstate graphics_device:dir search;
-allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
-allow dumpstate debugfs_mmc:dir r_dir_perms;
 allow dumpstate sysfs_zram:dir r_dir_perms;

--- a/graphics/mesa_xen/file.te
+++ b/graphics/mesa_xen/file.te
@@ -16,8 +16,6 @@ type sysfs_videostatus, fs_type, sysfs_type;
 # i915 related /proc/driver entry.
 type proc_graphics, fs_type, proc_type;
 
-type debugfs_graphics, fs_type, debugfs_type;
-
 type sysfs_app_readable, fs_type, sysfs_type;
 
 typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;

--- a/graphics/mesa_xen/file_contexts
+++ b/graphics/mesa_xen/file_contexts
@@ -20,8 +20,6 @@
 # i915 videostatus
 /sys/devices/pci0000:00/0000:00:02.0/drm/card0/power/i915_videostatus u:object_r:sysfs_videostatus:s0
 
-/sys/kernel/debug/dri/0/i915_frequency_info u:object_r:debugfs_graphics:s0
-
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0

--- a/graphics/ufo_common/coreu.te
+++ b/graphics/ufo_common/coreu.te
@@ -59,9 +59,5 @@ allow coreu sysfs_gfx:file rw_file_perms;
 
 allow coreu proc_graphics:file r_file_perms;
 
-#debugfs
-allow coreu debugfs_tracing:file rw_file_perms;
-allow coreu debugfs_graphics:file rw_file_perms;
-
 # drm detecting
 allow coreu mediadrmserver:process signull;

--- a/graphics/ufo_common/file.te
+++ b/graphics/ufo_common/file.te
@@ -17,8 +17,6 @@ type sysfs_videostatus, fs_type, sysfs_type;
 # i915 related /proc/driver entry.
 type proc_graphics, fs_type, proc_type;
 
-type debugfs_graphics, fs_type, debugfs_type;
-
 type sysfs_app_readable, fs_type, sysfs_type;
 
 typeattribute hal_graphics_allocator_default_tmpfs mlstrustedobject;

--- a/graphics/ufo_common/file_contexts
+++ b/graphics/ufo_common/file_contexts
@@ -15,8 +15,6 @@
 # i915 videostatus
 /sys/devices/pci0000:00/0000:00:02.0/drm/card0/power/i915_videostatus u:object_r:sysfs_videostatus:s0
 
-/sys/kernel/debug/dri/0/i915_frequency_info u:object_r:debugfs_graphics:s0
-
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0

--- a/kernel/file.te
+++ b/kernel/file.te
@@ -1,1 +1,0 @@
-type debugfs_pstate, fs_type, debugfs_type;

--- a/kernel/file_contexts
+++ b/kernel/file_contexts
@@ -1,1 +1,0 @@
-/sys/kernel/debug/pstate_snb/setpoint u:object_r:debugfs_pstate:s0

--- a/kernel/init.te
+++ b/kernel/init.te
@@ -2,12 +2,6 @@
 # init
 #
 
-# mixin kernel/init.rc write to /sys/kernel/debug/pstate_snb/setpoint
-allow init debugfs_pstate:file w_file_perms;
-
-#avc: denied { write } for pid=1 comm="init" name="psys_force_freq" dev="debugfs" ino=8600 scontext=u:r:init:s0 tcontext=u:object_r:debugfs:s0 tclass=file permissive=0
-allow init debugfs:file write;
-
 # allow init insmod keyword
 allow init kernel:key search;
 allow init {

--- a/kernel/kernel.te
+++ b/kernel/kernel.te
@@ -12,6 +12,3 @@ allow kernel kernel:capability sys_admin;
 # For loading /lib/modules/inet_diag.ko
 allow kernel rootfs:system module_load;
 allow kernel system_file:system module_load;
-
-# For adding mmc debugfs directory in the runtime
-allow kernel debugfs_mmc:dir search;

--- a/neuralnetworks/file_contexts
+++ b/neuralnetworks/file_contexts
@@ -1,4 +1,4 @@
-/(vendor|system/vendor)/bin/hw/android\.hardware\.neuralnetworks@1\.2-generic-service   u:object_r:hal_neuralnetworks_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.hardware\.neuralnetworks@1\.3-generic-service   u:object_r:hal_neuralnetworks_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.hardware\.neuralnetworks@1\.2-service-gpgpu   u:object_r:hal_neuralnetworks_default_exec:s0
 /data/vendor/neuralnetworks(/.*)?    u:object_r:nn_vendor_data_file:s0
 /vendor/etc/openvino(/.*)?           u:object_r:openvino_etc_file:s0

--- a/neuralnetworks/hal_neuralnetworks.te
+++ b/neuralnetworks/hal_neuralnetworks.te
@@ -9,13 +9,18 @@ allow hal_neuralnetworks_default self:process execmem;
 
 allow hal_neuralnetworks_default vendor_data_file:file { open read write };
 allow hal_neuralnetworks_default vendor_data_file:dir rw_dir_perms;
+
 set_prop(hal_neuralnetworks_default, vendor_nnhal_prop)
+get_prop(hal_neuralnetworks_default, vendor_nnhal_prop)
 
 # allow hal_neuralnetworks to access libusb
 allow hal_neuralnetworks_default usb_device:dir r_dir_perms;
 allow hal_neuralnetworks_default usb_device:chr_file rw_file_perms;
 
 allow hal_neuralnetworks_default self:netlink_kobject_uevent_socket { read bind create setopt };
+
+# allow hal_neuralnetworks to use vsock
+allow hal_neuralnetworks_default self:vsock_socket { create read write connect getopt setopt };
 
 dontaudit hal_neuralnetworks_default self:capability { dac_read_search dac_override };
 allow hal_neuralnetworks_default sysfs:dir r_dir_perms;

--- a/neuralnetworks/property_contexts
+++ b/neuralnetworks/property_contexts
@@ -1,1 +1,1 @@
-vendor.nn.hal.ngraph    u:object_r:vendor_nnhal_prop:s0
+vendor.nn.hal.    u:object_r:vendor_nnhal_prop:s0

--- a/sensors/mediation/sensor_hal_default.te
+++ b/sensors/mediation/sensor_hal_default.te
@@ -4,8 +4,4 @@ allow hal_sensors_default self:socket create_socket_perms;
 allowxperm hal_sensors_default self:socket ioctl unpriv_sock_ioctls;
 allow hal_sensors_default serial_device:chr_file rw_file_perms;
 
-allow hal_sensors_default self:tcp_socket { create read write connect name_connect getopt setopt };
-dontaudit hal_sensors_default default_prop:file { open read getattr map };
-allow hal_sensors_default port:tcp_socket { name_connect };
-
-get_prop(hal_sensors_default, vendor_intel_ipaddr_prop)
+allow hal_sensors_default self:vsock_socket { create read write connect getopt setopt };

--- a/soc/file_contexts
+++ b/soc/file_contexts
@@ -1,0 +1,1 @@
+(/system)?/vendor/bin/set_soc_prop.sh u:object_r:set_soc_prop_exec:s0

--- a/soc/property.te
+++ b/soc/property.te
@@ -1,0 +1,1 @@
+vendor_internal_prop(vendor_cpu_model_name_prop)

--- a/soc/property_contexts
+++ b/soc/property_contexts
@@ -1,0 +1,1 @@
+vendor.cpu.model_name u:object_r:vendor_cpu_model_name_prop:s0

--- a/soc/set_soc_prop.te
+++ b/soc/set_soc_prop.te
@@ -1,0 +1,18 @@
+# Rules for soc
+type set_soc_prop, domain;
+type set_soc_prop_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(set_soc_prop)
+
+allow set_soc_prop proc_cpuinfo:file r_file_perms;
+allow set_soc_prop vendor_toolbox_exec:file execute_no_trans;
+
+set_prop(set_soc_prop, vendor_cpu_model_name_prop)
+
+not_full_treble(`
+  allow set_soc_prop system_file:file rx_file_perms;
+  allow set_soc_prop shell_exec:file rx_file_perms;
+')
+full_treble_only(`
+  allow set_soc_prop vendor_shell_exec:file rx_file_perms;
+  allow set_soc_prop vendor_toolbox_exec:file rx_file_perms;
+')

--- a/soc/shell.te
+++ b/soc/shell.te
@@ -1,0 +1,1 @@
+allow shell set_soc_prop_exec:file getattr;

--- a/soc/vendor_init.te
+++ b/soc/vendor_init.te
@@ -1,0 +1,1 @@
+set_prop(vendor_init, vendor_cpu_model_name_prop)

--- a/system_ext/private/mediatranscoding.te
+++ b/system_ext/private/mediatranscoding.te
@@ -1,0 +1,6 @@
+# mediatranscoding - daemon for transcoding video and image.
+allow mediatranscoding surfaceflinger_service:service_manager find;
+allow mediatranscoding gpu_device:dir { open read search };
+allow mediatranscoding gpu_device:chr_file { getattr ioctl map open read write };
+allow mediatranscoding graphics_device:chr_file { getattr };
+

--- a/vendor/dumpstate.te
+++ b/vendor/dumpstate.te
@@ -3,3 +3,4 @@ dontaudit dumpstate device:file write;
 dontaudit dumpstate unlabeled:file read;
 allow dumpstate hal_power_default:binder call;
 allow dumpstate hal_light_default:binder call;
+allow dumpstate gpu_device:dir r_dir_perms;

--- a/vendor/ueventd.te
+++ b/vendor/ueventd.te
@@ -1,1 +1,0 @@
-allow ueventd debugfs_wakeup_sources:file r_file_perms;


### PR DESCRIPTION
    EVS sample driver not getting started as service due to missing sepolicies and onrestart automotive_display trigger.

    Changes done to fix the issue:

    Allow carservice_app with service find rights
    Allow carservice_app with open, read and search access for sysfs dir Allow carservice_app with search access for data folder

    Tracked-On: OAM-108953
