### PR TITLE
Fix EVS sample driver not getting started as service

### DIFF
--- a/camera-ext/ext-camera-only/file_contexts
+++ b/camera-ext/ext-camera-only/file_contexts
@@ -1,1 +1,2 @@
 /dev/media[0-9]+          u:object_r:video_device:s0
+/(vendor|system/vendor)/bin/android\.hardware\.automotive\.evs@1\.[0-9]-sample  u:object_r:hal_evs_default_exec:s0

--- a/car/carservice_app.te
+++ b/car/carservice_app.te
@@ -1,6 +1,11 @@
 allow carservice_app sysfs:dir r_dir_perms;
 allow carservice_app sysfs_fs_f2fs:dir r_dir_perms;
 allow carservice_app sysfs_fs_ext4_features:dir r_dir_perms;
+allow carservice_app system_data_file:dir search;
+allow carservice_app user_profile_root_file:dir search;
+allow carservice_app content_capture_service:service_manager find;
+allow carservice_app game_service:service_manager find;
+allow carservice_app media_communication_service:service_manager find;
 
 # To allow carservice app to  access sys.usb.cfg
 module_only(`carservice_app', `


### PR DESCRIPTION
EVS sample driver not getting started as service due to missing sepolicies

Changes done to fix the issue:
- Allow carservice_app with service find rights
- Allow carservice_app with open, read and search access for sysfs dir
- Allow carservice_app with search access for data folder

Tracked-On: OAM-108953