### PR TITLE
Add selinux genfscon rules for suspend

### DIFF
--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -3,5 +3,27 @@ genfscon sysfs /devices/pnp0/00:00/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:03/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:04/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pci0000:00/0000:00:05.0 u:object_r:sysfs_virtio:s0
+
+#SuspendSepolicy
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:02/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:03/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:0c/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:00/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:01/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:04/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:05/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:06/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:07/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:08/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:09/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:0a/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:0b/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/pci0000:00/0000:00:08.0/usb1/1-2/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/LNXSYSTM:00/LNXPWRBN:00/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/pnp0/00:03/rtc/rtc0/alarmtimer.1.auto/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/pci0000:00/0000:00:09.0/usb1/1-2/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/pnp0/00:03/wakeup u:object_r:sysfs_wakeup:s0
+
 genfscon proc  /sys/vm/swappiness        u:object_r:proc_swappiness:s0
 genfscon proc  /sys/vm/disk_based_swap   u:object_r:proc_disk_based_swap:s0


### PR DESCRIPTION
Suspend is Android-T added new VTS test case,
which is trying to verify genfs rules for
Unlabeled wakeup nodes found, your device is likely missing device/oem specific selinux genfscon rules for suspend. Please review and add the following generated rules to the device specific genfs_contexts:
genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:02/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:03/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:0c/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:00/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:01/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:04/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:05/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:06/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:07/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:08/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:09/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:0a/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:0b/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/pci0000:00/0000:00:08.0/usb1/1-2/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/LNXSYSTM:00/LNXPWRBN:00/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/pnp0/00:03/rtc/rtc0/alarmtimer.1.auto/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/pci0000:00/0000:00:09.0/usb1/1-2/wakeup u:object_r:sysfs_wakeup:s0 genfscon sysfs /devices/pnp0/00:03/wakeup u:object_r:sysfs_wakeup:s0

Tracked-On: OAM-111173