### PR TITLE
Enable SELinux for ivi

### DIFF
--- a/audio/hal_audiocontrol_default.te
+++ b/audio/hal_audiocontrol_default.te
@@ -1,0 +1,3 @@
+hal_client_domain(carpowerpolicyd, hal_audiocontrol);
+get_prop(hal_audiocontrol_default, boot_status_prop);
+carpowerpolicy_callback_domain(hal_audiocontrol_default)

--- a/car/file.te
+++ b/car/file.te
@@ -1,1 +1,2 @@
 type sysfs_early_evs, fs_type, sysfs_type;
+type sysfs_video, sysfs_type, fs_type;

--- a/car/file_contexts
+++ b/car/file_contexts
@@ -3,3 +3,5 @@
 
 /vendor/bin/hw/android.hardware.broadcastradio@intel-service u:object_r:hal_broadcastradio_default_exec:s0
 /vendor/bin/hw/android.hardware.automotive.audiocontrol@1.0-service.intel u:object_r:hal_audiocontrol_default_exec:s0
+
+/dev/v4l-subdev.*                               u:object_r:video_device:s0

--- a/car/genfs_contexts
+++ b/car/genfs_contexts
@@ -9,3 +9,4 @@ genfscon sysfs /fs/ext4/loop5/lifetime_write_kbytes u:object_r:sysfs_fs_lifetime
 genfscon sysfs /fs/ext4/sda8/lifetime_write_kbytes u:object_r:sysfs_fs_lifetime_write:s0
 genfscon sysfs /fs/ext4/sda13/lifetime_write_kbytes u:object_r:sysfs_fs_lifetime_write:s0
 genfscon sysfs /fs/ext4/sda18/lifetime_write_kbytes u:object_r:sysfs_fs_lifetime_write:s0
+genfscon sysfs /class/video4linux u:object_r:sysfs_video:s0

--- a/car/hal_camera_default.te
+++ b/car/hal_camera_default.te
@@ -1,0 +1,1 @@
+allowxperm hal_evs_default video_device:chr_file ioctl { VIDIOC_QUERYCAP };

--- a/car/hal_evs_default.te
+++ b/car/hal_evs_default.te
@@ -1,0 +1,14 @@
+allow hal_evs_default self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;
+allow hal_evs_default video_device:chr_file rw_file_perms;
+allow hal_evs_default sysfs_video:dir r_dir_perms;
+allow hal_evs_default device:dir r_dir_perms;
+allowxperm hal_evs_default video_device:chr_file ioctl {
+    VIDIOC_G_INPUT
+    MEDIA_IOC_DEVICE_INFO
+    MEDIA_IOC_ENUM_ENTITIES
+    VIDIOC_ENUM_FMT
+    MEDIA_IOC_ENUM_LINKS
+    VIDIOC_S_FMT
+    MEDIA_IOC_SETUP_LINK
+    VIDIOC_QUERYCAP
+};

--- a/crashlogd/vendor_init.te
+++ b/crashlogd/vendor_init.te
@@ -13,5 +13,4 @@ userdebug_or_eng(`
   dontaudit vendor_init log_file:lnk_file create_file_perms;
   dontaudit vendor_init cache_file:dir { relabelfrom relabelto };
 # data_between_core_and_vendor_violators
-  dontaudit vendor_init system_data_file:dir create_dir_perms;
 ')

--- a/graphics/mesa/genfs_contexts
+++ b/graphics/mesa/genfs_contexts
@@ -1,4 +1,5 @@
 genfscon proc /driver/i915rpm/i915_rpm_op u:object_r:proc_graphics:s0
+genfscon proc /sys/dev/i915/perf_stream_paranoid u:object_r:proc_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:02.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:01.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:03.0/ u:object_r:sysfs_app_readable:s0

--- a/graphics/mesa/platform_app.te
+++ b/graphics/mesa/platform_app.te
@@ -1,1 +1,2 @@
 allow platform_app graphics_device:dir search;
+allow platform_app proc_graphics:file r_file_perms;

--- a/graphics/mesa/system_app.te
+++ b/graphics/mesa/system_app.te
@@ -1,1 +1,2 @@
 allow system_app graphics_device:dir search;
+allow system_app proc_graphics:file r_file_perms;

--- a/graphics/mesa/system_server.te
+++ b/graphics/mesa/system_server.te
@@ -3,3 +3,4 @@ allow system_server platform_app:file { read write };
 allow system_server priv_app:file { read write };
 allow system_server gpu_device:dir r_dir_perms;
 allow system_server sysfs_app_readable:file r_file_perms;
+allow system_server proc_graphics:file r_file_perms;

--- a/light/hal_light_default.te
+++ b/light/hal_light_default.te
@@ -1,3 +1,4 @@
 # allow hal_light_default set brightness for light module
 allow hal_light_default sysfs_backlight:file rw_file_perms;
 allow hal_light_default sysfs_backlight_thermal:dir search;
+allow hal_light_default sysfs_app_readable:file rw_file_perms;

--- a/thermal/thermal-daemon/genfs_contexts
+++ b/thermal/thermal-daemon/genfs_contexts
@@ -1,3 +1,4 @@
 genfscon sysfs /devices/virtual/dmi/id/product_name u:object_r:sysfs_dmi_id:s0
 genfscon sysfs /devices/virtual/dmi/id/product_uuid u:object_r:sysfs_dmi_id:s0
 genfscon sysfs /class/backlight	u:object_r:sysfs_backlight_thermal:s0
+genfscon sysfs /class/thermal u:object_r:sysfs_thermal:s0

--- a/thermal/thermal-daemon/hal_thermal_intel.te
+++ b/thermal/thermal-daemon/hal_thermal_intel.te
@@ -9,6 +9,8 @@ vndbinder_use(hal_thermal_intel)
 add_service(hal_thermal_intel, thermal_hal_service)
 
 allow hal_thermal_intel sysfs_thermal_management:dir r_dir_perms;
+allow hal_thermal_intel sysfs_thermal_management:file r_file_perms;
+allow hal_thermal_intel sysfs_thermal:dir r_dir_perms;
 allow hal_thermal_intel sysfs_thermal:file r_file_perms;
 allow hal_thermal_intel proc_stat:file r_file_perms;
 allow hal_thermal_intel serial_device:chr_file rw_file_perms;

--- a/thermal/thermal-daemon/thermal-daemon.te
+++ b/thermal/thermal-daemon/thermal-daemon.te
@@ -24,6 +24,7 @@ allow thermal-daemon sysfs_leds:file rw_file_perms;
 allow thermal-daemon sysfs_backlight_thermal:dir r_dir_perms;
 allow thermal-daemon sysfs_backlight_thermal:file rw_file_perms;
 allow thermal-daemon sysfs_dmi_id:{ file lnk_file } rw_file_perms;
+allow thermal-daemon sysfs_app_readable:file rw_file_perms;
 allow thermal-daemon vendor_data_file:dir create_dir_perms;
 allow thermal-daemon vendor_data_file:dir rw_dir_perms;
 allow thermal-daemon thermal-daemon_run_dir:dir create_dir_perms;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -1,3 +1,4 @@
 /vendor/bin/logwrapper      u:object_r:logwrapper_exec:s0
 /vendor/bin/hw/android\.hardware\.graphics\.allocator@4\.0-service\.minigbm   u:object_r:hal_graphics_allocator_default_exec:s0
 /vendor/lib(64)?/hw/android\.hardware\.graphics\.mapper@4\.0-impl\.minigbm\.so u:object_r:same_process_hal_file:s0
+/vendor/lib(64)?/libippcustom\.so   u:object_r:same_process_hal_file:s0

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -3,5 +3,6 @@ genfscon sysfs /devices/pnp0/00:00/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:03/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:04/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pci0000:00/0000:00:05.0 u:object_r:sysfs_virtio:s0
+genfscon sysfs /power/pm_silentmode_hw_state u:object_r:sysfs_power:s0
 genfscon proc  /sys/vm/swappiness        u:object_r:proc_swappiness:s0
 genfscon proc  /sys/vm/disk_based_swap   u:object_r:proc_disk_based_swap:s0

--- a/vendor/init.te
+++ b/vendor/init.te
@@ -1,1 +1,2 @@
 allow init tmpfs:lnk_file create;
+allow init vendor_data_file:dir mounton;


### PR DESCRIPTION
Add some essential sepolicy rules for ivi, so that ivi devices can boot up with SELinux in enforcing mode.

Tracked-On: OAM-112152