### PR TITLE
Add vendor/iw command security policy

### DIFF
--- a/wlan/iwlwifi/file_contexts
+++ b/wlan/iwlwifi/file_contexts
@@ -1,1 +1,2 @@
 /system/bin/wlan_intel_restore.sh  u:object_r:wlan_intel_restore_exec:s0
+/vendor/bin/iw  u:object_r:iw_vendor_exec:s0

--- a/wlan/iwlwifi/genfs_contexts
+++ b/wlan/iwlwifi/genfs_contexts
@@ -1,0 +1,1 @@
+genfscon sysfs /devices/pci0000:00/0000:00:1c.0/0000:02:00.0/ieee80211/phy0 u:object_r:sysfs_net:s0

--- a/wlan/iwlwifi/iw_vendor.te
+++ b/wlan/iwlwifi/iw_vendor.te
@@ -1,0 +1,8 @@
+type iw_vendor, domain;
+type iw_vendor_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(iw_vendor)
+
+allow iw_vendor self:netlink_generic_socket create_socket_perms_no_ioctl;
+allow iw_vendor self:global_capability_class_set { sys_admin net_admin };
+allow iw_vendor sysfs_net:file r_file_perms;
+allow iw_vendor sysfs_net:dir r_dir_perms;


### PR DESCRIPTION
Fix for sepolicy blocking iw in creating wifi AP interface
iw is not able to create Wi-Fi AP interface due to sepolicy.
As iw is built as system package, addition of sepolicy requires
changes to system/sepolicy which is not recommended. So, using
the vendor iw package instead of system iw package.

Tracked-On: OAM-112388