### PR TITLE
Add getattr for kernel to read firmware from /vendor/firmware

### DIFF
--- a/bluetooth/common/kernel.te
+++ b/bluetooth/common/kernel.te
@@ -1,3 +1,0 @@
-#allow read permission for Bluetooth firmware file
-allow kernel vendor_file:file { open read };
-

--- a/kernel/kernel.te
+++ b/kernel/kernel.te
@@ -12,3 +12,6 @@ allow kernel kernel:capability sys_admin;
 # For loading /lib/modules/inet_diag.ko
 allow kernel rootfs:system module_load;
 allow kernel system_file:system module_load;
+
+# allow read permission for firmware file read from /vendor/firmware
+allow kernel vendor_file:file { open read getattr };


### PR DESCRIPTION
Read of firmware from /vendor/firmware failing due to missing sepolicy.

few avc denied messages:
avc: denied { getattr } for comm="kworker/u33:5"
name="ibt-0040-0041.sfi" dev="dm-1" ino=541 scontext=u:r:kernel:s0 tcontext=u:object_r:vendor_file:s0 tclass=file permissive=0

avc: denied { getattr } for name="iwlwifi-ty-a0-gf-a0-72.ucode" dev="dm-1" ino=827 scontext=u:r:kernel:s0
tcontext=u:object_r:vendor_file:s0 tclass=file permissive=0

Fix the issue by adding getattr permission for kernel to read firmware file from /vendor/firmware.

Test done:
- Verified boot to UI
- adb remount, adb reboot
- Audio playback
- Wi-Fi and BT

Tracked-On: