### PR TITLE
Fix for Wi-Fi hotspot not working due to missing sepolicy

### DIFF
--- a/wlan/iwlwifi/genfs_contexts
+++ b/wlan/iwlwifi/genfs_contexts
@@ -1,1 +1,3 @@
 genfscon sysfs /devices/pci0000:00/0000:00:1c.0/0000:02:00.0/ieee80211/phy0 u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:1c.0/0000:03:00.0/ieee80211/phy0 u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:14.3/ieee80211/phy0 u:object_r:sysfs_net:s0


### PR DESCRIPTION
Wi-Fi hotspot not working with following sepolicy error: avc: denied { read } for comm="iw" name="index" dev="sysfs" ino=46194 scontext=u:r:iw_vendor:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

avc: denied { open } for comm="iw"
path="/sys/devices/pci0000:00/0000:00:1c.0/0000:03:00.0/ieee80211/phy0/index" dev="sysfs" ino=46194 scontext=u:r:iw_vendor:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Assigned security context sysfs_net to sysfs Wi-Fi PCI device path /sys/devices/pci0000:00/0000:00:1c.0/0000:03:00.0/ieee80211/phy0/index.

Tracked-On: OAM-112475