### PR TITLE
Add some rules for vehicle and media apps

### DIFF
--- a/car/platform_app.te
+++ b/car/platform_app.te
@@ -4,3 +4,5 @@ allow platform_app carservice_service:service_manager find;
 #allow SystemUpdater app to call UpdateEngine
 allow platform_app update_engine:binder { call transfer };
 allow platform_app update_engine_service:service_manager find;
+allow platform_app hal_vehicle_default:binder call;
+hal_client_domain(platform_app, hal_vehicle)

--- a/vendor/mediaextractor.te
+++ b/vendor/mediaextractor.te
@@ -1,0 +1,3 @@
+userdebug_or_eng(`
+  allow mediaextractor shell_data_file:file read;
+')

--- a/vendor/mediaserver.te
+++ b/vendor/mediaserver.te
@@ -1,0 +1,3 @@
+userdebug_or_eng(`
+  allow mediaserver shell_data_file:file read;
+')


### PR DESCRIPTION
Add permissions in userdebug or eng build to support validation testing.

    - Test videos can be pushed to /data/local/tmp/ for validation.
    Allow media apps to read from /data/local/tmp directory.

    - Car kitchensink app need to access the vehicle services to
    complete some tests.

Tracked-On: OAM-112560
Tracked-On: OAM-112610