### PR TITLE
Sepolicy to allow thermal daemon to read property.

### DIFF
--- a/thermal/thermal-daemon/property.te
+++ b/thermal/thermal-daemon/property.te
@@ -1,0 +1,2 @@
+vendor_internal_prop(vendor_disable_thermal_logs_prop)
+vendor_internal_prop(vendor_thermal_daemon_supported_prop)

--- a/thermal/thermal-daemon/property_contexts
+++ b/thermal/thermal-daemon/property_contexts
@@ -1,0 +1,2 @@
+persist.vendor.disable.thermal.logs u:object_r:vendor_disable_thermal_logs_prop:s0
+persist.vendor.thermal.daemon.supported    u:object_r:vendor_thermal_daemon_supported_prop:s0

--- a/thermal/thermal-daemon/thermal-daemon.te
+++ b/thermal/thermal-daemon/thermal-daemon.te
@@ -37,4 +37,6 @@ allowxperm thermal-daemon self:netlink_kobject_uevent_socket ioctl SIOCETHTOOL;
 allow thermal-daemon vendor_file:dir read;
 
 # properties
+get_prop(thermal-daemon, vendor_disable_thermal_logs_prop)
 set_prop(thermal-daemon, powerctl_prop)
+allow thermal-daemon vendor_thermal_prop:property_service set;


### PR DESCRIPTION
This commit introduces a new sepolicy rule that grants thermal daemon the necessary permissions to read properties, enabling it to function correctly and access required information.

Tracked-On: OAM-112768