### PR TITLE
Add file label for vendor_boot_a/b partitions

### DIFF
--- a/boot-arch/generic/file_contexts
+++ b/boot-arch/generic/file_contexts
@@ -2,6 +2,7 @@
 # Block Devices
 #
 /dev/block/by-name/boot(_(a|b))?	u:object_r:boot_block_device:s0
+/dev/block/by-name/vendor_boot(_(a|b))?	u:object_r:boot_block_device:s0
 /dev/block/by-name/bootloader(_(a|b))?	u:object_r:boot_block_device:s0
 /dev/block/by-name/multiboot(_(a|b))?	u:object_r:boot_block_device:s0
 /dev/block/by-name/system(_(a|b))?	u:object_r:system_block_device:s0


### PR DESCRIPTION
This is needed by update_engine during OTA process.

Tracked-On: OAM-112787