### PR TITLE
Add sepolicy for bootcontrol service

### DIFF
--- a/slot-ab/file_contexts
+++ b/slot-ab/file_contexts
@@ -1,0 +1,1 @@
+/vendor/bin/hw/android\.hardware\.boot-service\.intel u:object_r:hal_bootctl_default_exec:s0


### PR DESCRIPTION
New service vendor.boot-default created for bootcontrol, allow
launching specified application for service.

Tracked-On: OAM-112811