### PR TITLE
Update sepolicy for AIDL minigbm and mapper

### DIFF
--- a/graphics/mesa/bootanim.te
+++ b/graphics/mesa/bootanim.te
@@ -6,3 +6,4 @@ allow bootanim graphics_device:chr_file { ioctl open read };
 allow bootanim graphics_device:dir search;
 allow bootanim self:process execmem;
 allow bootanim proc_graphics:file r_file_perms;
+allow bootanim hal_graphics_allocator_default_tmpfs:file { map read write };

--- a/graphics/mesa/hal_graphics_composer_default.te
+++ b/graphics/mesa/hal_graphics_composer_default.te
@@ -25,3 +25,4 @@ dontaudit hal_graphics_composer_default default_prop:file *;
 
 allow hal_graphics_composer_default sysfs:file { open read };
 allow hal_graphics_composer_default uio_device:chr_file { map open read write };
+allow hal_graphics_composer_default hal_graphics_allocator_default_tmpfs:file { read write map };

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -1,3 +1,7 @@
 /vendor/bin/logwrapper      u:object_r:logwrapper_exec:s0
-/vendor/bin/hw/android\.hardware\.graphics\.allocator@4\.0-service\.minigbm   u:object_r:hal_graphics_allocator_default_exec:s0
-/vendor/lib(64)?/hw/android\.hardware\.graphics\.mapper@4\.0-impl\.minigbm\.so u:object_r:same_process_hal_file:s0
+/vendor/bin/hw/android\.hardware\.graphics\.allocator-service\.minigbm   u:object_r:hal_graphics_allocator_default_exec:s0
+/vendor/bin/hw/android\.hardware\.graphics\.allocator@4\.0-service\.minigbm_intel   u:object_r:hal_graphics_allocator_default_exec:s0
+/vendor/lib(64)?/hw/android\.hardware\.graphics\.mapper@4\.0-impl\.minigbm_intel\.so u:object_r:same_process_hal_file:s0
+/vendor/lib(64)?/hw/mapper\.minigbm\.so u:object_r:same_process_hal_file:s0
+/vendor/lib(64)?/libminigbm_gralloc_intel.so u:object_r:same_process_hal_file:s0
+/vendor/lib(64)?/libminigbm_gralloc4_utils.so  u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
Changes include:
- Added sepolicy for libminigbm_gralloc_intel
- Update gralloc and mapper names
- allow bootanim and hwcomposer to access file hal_graphics_allocator_default_tmpfs

Tracked-On: OAM-112813