### PR TITLE
SELinux change for AIDL Conversion of Thermal HAL

### DIFF
--- a/thermal/thermal-daemon/file_contexts
+++ b/thermal/thermal-daemon/file_contexts
@@ -4,3 +4,4 @@
 
 # thermal service
 /vendor/bin/hw/android\.hardware\.thermal@2\.0-service\.intel u:object_r:hal_thermal_intel_exec:s0
+/vendor/bin/hw/android\.hardware\.thermal@aidl-service\.intel u:object_r:hal_thermal_intel_exec:s0


### PR DESCRIPTION
This change will add file_context for AIDL
Thermal HAL.

Tracked-On: OAM-112805