### PR TITLE
Support OTA from U disk with exfat fs

### DIFF
--- a/virtual_ab/update_engine.te
+++ b/virtual_ab/update_engine.te
@@ -2,3 +2,5 @@ allow update_engine proc_bootconfig:file r_file_perms;
 allow update_engine vd_device:blk_file rw_file_perms;
 allowxperm update_engine vd_device:blk_file ioctl BLKROGET;
 allow update_engine dm_user_device:chr_file r_file_perms;
+allow update_engine exfat:file r_file_perms;
+allow update_engine exfat:dir search;


### PR DESCRIPTION
OTA packages may locate in a U disk with exfat fs, update_engine needs the read permissions of U disk with exfat fs to do the OTA.

Tests done: update_engine can read OTA packages from U disk with exfat fs.

Tracked-On: OAM-113303