### PR TITLE
Add file label for tee_a/b partitions

### DIFF
--- a/tee/optee/file_contexts
+++ b/tee/optee/file_contexts
@@ -10,3 +10,5 @@
 
 # optee keymaster treble service
 /vendor/bin/hw/android.hardware.keymaster@3.0-service.optee       u:object_r:hal_keymaster_default_exec:s0
+
+/dev/block/by-name/tee(_(a|b))? u:object_r:boot_block_device:s0


### PR DESCRIPTION
This is needed by update_engine during OTA process.

Test done: tee partition can be updated during OTA.

Tracked-On: OAM-115179