### PR TITLE
Add sepolicy to allow thermal daemon to set property

### DIFF
--- a/thermal/thermal-daemon/thermal-daemon.te
+++ b/thermal/thermal-daemon/thermal-daemon.te
@@ -38,5 +38,7 @@ allow thermal-daemon vendor_file:dir read;
 
 # properties
 get_prop(thermal-daemon, vendor_disable_thermal_logs_prop)
+get_prop(thermal-daemon, vendor_thermal_daemon_supported_prop)
+set_prop(thermal-daemon, vendor_thermal_daemon_supported_prop)
 set_prop(thermal-daemon, powerctl_prop)
 allow thermal-daemon vendor_thermal_prop:property_service set;


### PR DESCRIPTION
Add sepolicy rules to allow thermal daemon to set property: persist.vendor.disable.thermal.logs
persist.vendor.thermal.daemon.supported

Tracked-On: OAM-115389