### PR TITLE
Add permissions for postinstall to access Intel WMI SBL interface

### DIFF
--- a/boot-arch/generic/file.te
+++ b/boot-arch/generic/file.te
@@ -1,0 +1,1 @@
+type sysfs_wmi_firmware, fs_type, sysfs_type;

--- a/boot-arch/generic/genfs_contexts
+++ b/boot-arch/generic/genfs_contexts
@@ -1,1 +1,2 @@
 genfscon sysfs /devices/platform/ANDR0001:00/properties/android u:object_r:sysfs_dt_firmware_android:s0
+genfscon sysfs /devices/platform/PNP0C14:00/wmi_bus/wmi_bus-PNP0C14:00/44FADEB1-B204-40F2-8581-394BBDC1B651/firmware_update_request u:object_r:sysfs_wmi_firmware:s0

--- a/boot-arch/generic/postinstall.te
+++ b/boot-arch/generic/postinstall.te
@@ -1,0 +1,1 @@
+allow postinstall sysfs_wmi_firmware:file w_file_perms;


### PR DESCRIPTION
postinstall needs to write Intel WMI SBL interface to trigger the SBL firmware update after an OTA.

Tracked-On: OAM-117059