### PR TITLE
Fix the treble violations introduced by crashlogd

### DIFF
--- a/crashlogd/file.te
+++ b/crashlogd/file.te
@@ -1,1 +1,1 @@
-type log_file, mlstrustedobject, file_type, data_file_type, core_data_file_type;
+type log_file, file_type, data_file_type, mlstrustedobject;

--- a/crashlogd/file_contexts
+++ b/crashlogd/file_contexts
@@ -11,7 +11,7 @@
 /cache/cache/elogs(/.*)?                 u:object_r:log_file:s0
 
 # Logs
-/data/logs(/.*)?                   u:object_r:log_file:s0
+/data/vendor/logs(/.*)?                   u:object_r:log_file:s0
 
 # aplog
 /vendor/bin/aplog.sh               u:object_r:logsvc_exec:s0

--- a/crashlogd/logsvc.te
+++ b/crashlogd/logsvc.te
@@ -27,9 +27,9 @@ userdebug_or_eng(`
   dontaudit logsvc cache_file:file *;
   dontaudit logsvc cache_file:dir rw_dir_perms;
   dontaudit logsvc cache_file:lnk_file create_file_perms;
-  dontaudit logsvc log_file:file create_file_perms;
-  dontaudit logsvc log_file:dir *;
-  dontaudit logsvc log_file:lnk_file create_file_perms;
+  allow logsvc log_file:file create_file_perms;
+  allow logsvc log_file:dir create_dir_perms;
+  allow logsvc log_file:lnk_file create_file_perms;
   dontaudit logsvc vendor_apklogfs_prop:file create_file_perms;
   dontaudit logsvc vendor_aplogfs_prop:file create_file_perms;
 


### PR DESCRIPTION
Vendor data files should be put under /data/vendor basing on Google's requirement, and their file contexts mustn't be core_data_file_type.

Tracked-On: OAM-117257