### PR TITLE
Allow postinstall to access Intel EC interface

### DIFF
--- a/boot-arch/generic/device.te
+++ b/boot-arch/generic/device.te
@@ -6,3 +6,5 @@ type odm_block_device, dev_type;
 typeattribute system_block_device super_block_device_type;
 typeattribute vendor_block_device super_block_device_type;
 typeattribute product_block_device super_block_device_type;
+
+type ec_device, dev_type;

--- a/boot-arch/generic/file.te
+++ b/boot-arch/generic/file.te
@@ -1,1 +1,2 @@
 type sysfs_wmi_firmware, fs_type, sysfs_type;
+type sysfs_ec, fs_type, sysfs_type;

--- a/boot-arch/generic/file_contexts
+++ b/boot-arch/generic/file_contexts
@@ -22,3 +22,5 @@
 /dev/block/by-name/acpi(_(a|b))?		u:object_r:acpi_block_device:s0
 /dev/block/by-name/acpio(_(a|b))?		u:object_r:acpio_block_device:s0
 /dev/block/by-name/super 		u:object_r:super_block_device:s0
+
+/dev/intel_ec					u:object_r:ec_device:s0

--- a/boot-arch/generic/genfs_contexts
+++ b/boot-arch/generic/genfs_contexts
@@ -1,2 +1,3 @@
 genfscon sysfs /devices/platform/ANDR0001:00/properties/android u:object_r:sysfs_dt_firmware_android:s0
 genfscon sysfs /devices/platform/PNP0C14:00/wmi_bus/wmi_bus-PNP0C14:00/44FADEB1-B204-40F2-8581-394BBDC1B651/firmware_update_request u:object_r:sysfs_wmi_firmware:s0
+genfscon sysfs /devices/virtual/misc/intel_ec u:object_r:sysfs_ec:s0

--- a/boot-arch/generic/postinstall.te
+++ b/boot-arch/generic/postinstall.te
@@ -1,1 +1,5 @@
 allow postinstall sysfs_wmi_firmware:file w_file_perms;
+allow postinstall sysfs_ec:file rw_file_perms;
+allow postinstall sysfs_ec:dir r_dir_perms;
+allow postinstall ec_device:chr_file rw_file_perms;
+allowxperm postinstall boot_block_device:blk_file ioctl BLKROSET;


### PR DESCRIPTION
To update EC firmware during the OTA postinstall stage, the postinstall domain needs read/write permissions to access Intel EC interface.

Tracked-On: OAM-117378