### PR TITLE
Enable SELinux for Android 14 for IVI

### DIFF
--- a/aafd/file.te
+++ b/aafd/file.te
@@ -1,1 +1,2 @@
 type p9fs2, fs_type, mlstrustedobject;
+type debugfs_graphics, fs_type, debugfs_type;

--- a/aafd/genfs_contexts
+++ b/aafd/genfs_contexts
@@ -1,2 +1,4 @@
 genfscon 9p / u:object_r:p9fs2:s0
 genfscon sysfs /class/udc u:object_r:sysfs_usb:s0
+genfscon debugfs /dri/0/i915_sriov_info u:object_r:debugfs_graphics:s0
+genfscon debugfs /dri/0/name u:object_r:debugfs_graphics:s0

--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -4,6 +4,7 @@ allow logwrapper vendor_file:file rx_file_perms;
 allow logwrapper sysfs:file r_file_perms;
 allow logwrapper proc:file r_file_perms;
 allow logwrapper kernel:system module_request;
+allow logwrapper debugfs_graphics:file r_file_perms;
 
 allow logwrapper self:bluetooth_socket create_socket_perms_no_ioctl;
 

--- a/aafd/logwrapper.te
+++ b/aafd/logwrapper.te
@@ -4,7 +4,9 @@ allow logwrapper vendor_file:file rx_file_perms;
 allow logwrapper sysfs:file r_file_perms;
 allow logwrapper proc:file r_file_perms;
 allow logwrapper kernel:system module_request;
-allow logwrapper debugfs_graphics:file r_file_perms;
+no_debugfs_restriction(`
+  allow logwrapper debugfs_graphics:file r_file_perms;
+')
 
 allow logwrapper self:bluetooth_socket create_socket_perms_no_ioctl;
 

--- a/car/hal_audiocontrol_default.te
+++ b/car/hal_audiocontrol_default.te
@@ -1,0 +1,1 @@
+typeattribute hal_audiocontrol_default carpowerpolicycallback_domain;

--- a/graphics/mesa/bootanim.te
+++ b/graphics/mesa/bootanim.te
@@ -1,9 +1,13 @@
 allow bootanim gpu_device:chr_file rw_file_perms;
 allow bootanim gpu_device:dir r_dir_perms;
 allow bootanim sysfs_app_readable:file r_file_perms;
+allow bootanim sysfs_gpu:dir r_dir_perms;
 allow bootanim tmpfs:file r_file_perms;
 allow bootanim graphics_device:chr_file { ioctl open read };
 allow bootanim graphics_device:dir search;
 allow bootanim self:process execmem;
 allow bootanim proc_graphics:file r_file_perms;
 allow bootanim hal_graphics_allocator_default_tmpfs:file { map read write };
+
+# Allow writing performance tracing data into the perfetto traced daemon.
+perfetto_producer(bootanim)

--- a/graphics/mesa/genfs_contexts
+++ b/graphics/mesa/genfs_contexts
@@ -1,4 +1,6 @@
 genfscon proc /driver/i915rpm/i915_rpm_op u:object_r:proc_graphics:s0
+genfscon proc /sys/dev/i915/ u:object_r:proc_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:02.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:01.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:03.0/ u:object_r:sysfs_app_readable:s0
+genfscon sysfs /devices/pci0000:00/0000:00:04.0/ u:object_r:sysfs_gpu:s0

--- a/graphics/mesa/platform_app.te
+++ b/graphics/mesa/platform_app.te
@@ -1,1 +1,2 @@
 allow platform_app graphics_device:dir search;
+allow platform_app sysfs_gpu:dir r_dir_perms;

--- a/graphics/mesa/surfaceflinger.te
+++ b/graphics/mesa/surfaceflinger.te
@@ -24,6 +24,7 @@ allow surfaceflinger hal_graphics_allocator_default_tmpfs:file { read write map 
 allow surfaceflinger hal_graphics_composer_default:dir search;
 allow surfaceflinger hal_graphics_composer_default:file { read getattr open };
 allow surfaceflinger gpu_device:dir r_dir_perms;
+allow surfaceflinger sysfs_gpu:dir r_dir_perms;
 allow surfaceflinger sysfs_app_readable:file r_file_perms;
 allow surfaceflinger self:process execmem;
 get_prop(surfaceflinger, vendor_graphics_gles_prop)

--- a/graphics/mesa/system_app.te
+++ b/graphics/mesa/system_app.te
@@ -1,1 +1,2 @@
 allow system_app graphics_device:dir search;
+allow system_app sysfs_gpu:dir r_dir_perms;

--- a/graphics/mesa/system_server.te
+++ b/graphics/mesa/system_server.te
@@ -3,3 +3,4 @@ allow system_server platform_app:file { read write };
 allow system_server priv_app:file { read write };
 allow system_server gpu_device:dir r_dir_perms;
 allow system_server sysfs_app_readable:file r_file_perms;
+allow system_server proc_graphics:file r_file_perms;

--- a/health_hal/dumpstate.te
+++ b/health_hal/dumpstate.te
@@ -1,0 +1,1 @@
+allow dumpstate sysfs_health2_0_management:file r_file_perms;

--- a/health_hal/init.te
+++ b/health_hal/init.te
@@ -1,0 +1,2 @@
+#Allow init to write discard_max_bytes
+allow init sysfs_health2_0_management:file w_file_perms;

--- a/rfkill/hal_bluetooth_vbt.te
+++ b/rfkill/hal_bluetooth_vbt.te
@@ -1,0 +1,1 @@
+allow hal_bluetooth_vbt rfkill_device:chr_file rw_file_perms;

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -3,6 +3,7 @@ genfscon sysfs /devices/pnp0/00:00/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:03/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pnp0/00:04/rtc   u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/pci0000:00/0000:00:05.0 u:object_r:sysfs_virtio:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1 u:object_r:sysfs_android_usb:s0
 
 #SuspendSepolicy
 genfscon sysfs /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:02/wakeup u:object_r:sysfs_wakeup:s0

--- a/wlan/load_iwl_modules/load_iwl_modules.te
+++ b/wlan/load_iwl_modules/load_iwl_modules.te
@@ -14,6 +14,7 @@ allow load_iwl_modules_script {
 }:system module_load;
 
 allow load_iwl_modules_script self:capability sys_module;
+allow load_iwl_modules_script self:key write;
 allow load_iwl_modules_script kernel:key search;
 allow load_iwl_modules_script rootfs:file r_file_perms;
 allow load_iwl_modules_script vendor_file:file rx_file_perms;


### PR DESCRIPTION
Write essential rules to let Android 14 for IVI boot up with selinux in enforcing mode.

Tracked-On: OAM-117568