### PR TITLE
Add ivi sepolicy

### DIFF
--- a/camera-ext/ivi/cameraserver.te
+++ b/camera-ext/ivi/cameraserver.te
@@ -1,0 +1,4 @@
+#============= cameraserver ==============
+allow cameraserver gpu_device:dir search;
+allow cameraserver gpu_device:chr_file rw_file_perms;
+allow cameraserver hal_graphics_allocator_default_tmpfs:file { read write map};

--- a/camera-ext/ivi/file_contexts
+++ b/camera-ext/ivi/file_contexts
@@ -1,0 +1,5 @@
+/dev/media[0-9]+          u:object_r:video_device:s0
+/(vendor|system/vendor)/bin/android\.hardware\.automotive\.evs@1\.[0-9]-sample  u:object_r:hal_evs_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.vendor\.hardware\.camera\.provider@2\.[0-9]+-ivi-service       u:object_r:hal_camera_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.vendor\.hardware\.camera\.provider@2\.[0-9]+-ivi-service       u:object_r:hal_camera_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.iacamera\.provider@2\.[0-9]+-ivi-service u:object_r:hal_camera_default_exec:s0

--- a/camera-ext/ivi/hal_camera_default.te
+++ b/camera-ext/ivi/hal_camera_default.te
@@ -1,0 +1,10 @@
+#============= hal_camera_default ==============
+vndbinder_use(hal_camera_default);
+
+allow hal_camera_default gpu_device:chr_file rw_file_perms;
+allow hal_camera_default gpu_device:dir search;
+allow hal_camera_default hal_graphics_allocator_default_tmpfs:file { map read write };
+allow hal_camera_default hal_graphics_mapper_hwservice:hwservice_manager find;
+allow hal_camera_default hal_graphics_composer_default:fd use;
+allow hal_camera_default self:{ socket vsock_socket } { create read write listen accept bind };
+set_prop(hal_camera_default, vendor_camera_default_prop)

--- a/camera-ext/ivi/init.te
+++ b/camera-ext/ivi/init.te
@@ -1,0 +1,6 @@
+#
+# init
+#
+
+# wait on /dev/video0 a shared buffer used for camera processing
+allow init video_device:chr_file getattr;

--- a/camera-ext/ivi/logwrapper.te
+++ b/camera-ext/ivi/logwrapper.te
@@ -1,0 +1,1 @@
+set_prop(logwrapper, vendor_camera_default_prop)

--- a/camera-ext/ivi/property.te
+++ b/camera-ext/ivi/property.te
@@ -1,0 +1,1 @@
+vendor_internal_prop(vendor_camera_default_prop)

--- a/camera-ext/ivi/property_contexts
+++ b/camera-ext/ivi/property_contexts
@@ -1,0 +1,8 @@
+ro.vendor.remote.sf.fake_camera                 u:object_r:vendor_camera_default_prop:s0
+ro.vendor.camera.in_frame_format.h264 u:object_r:vendor_camera_default_prop:s0
+ro.vendor.camera.in_frame_format.i420 u:object_r:vendor_camera_default_prop:s0
+ro.vendor.camera.decode.vaapi         u:object_r:vendor_camera_default_prop:s0
+ro.vendor.remote.sf.back_camera_hal             u:object_r:vendor_camera_default_prop:s0
+ro.vendor.remote.sf.front_camera_hal            u:object_r:vendor_camera_default_prop:s0
+ro.vendor.camera.transference         u:object_r:vendor_camera_default_prop:s0 
+vendor.camera.external         u:object_r:vendor_camera_default_prop:s0 

--- a/camera-ext/ivi/vendor_init.te
+++ b/camera-ext/ivi/vendor_init.te
@@ -1,0 +1,1 @@
+set_prop(vendor_init, vendor_camera_default_prop)


### PR DESCRIPTION
Issue Detailed: No iacamera hal sepolicy.

Fix Detailed: Enable iacamera hal sepolicy.

Tested On: AOSP camera app preview successfully.

Tracked-On: OAM-117417
Signed-off-by: Neo Fang <neo.fang@intel.com>