### PR TITLE
Label i915 sysfs files properly

### DIFF
--- a/graphics/mesa/genfs_contexts
+++ b/graphics/mesa/genfs_contexts
@@ -4,3 +4,4 @@ genfscon sysfs /devices/pci0000:00/0000:00:02.0/ u:object_r:sysfs_app_readable:s
 genfscon sysfs /devices/pci0000:00/0000:00:01.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:03.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:04.0/ u:object_r:sysfs_gpu:s0
+genfscon sysfs /devices/pci0000:00/0000:00:09.0/ u:object_r:sysfs_app_readable:s0


### PR DESCRIPTION
Label i915 sysfs files properly on MBL board, so surfaceflinger, bootanim, system_server etc. can access the related files.

Test done: Android 14 on MBL board can boot successfully.

Tracked-On: OAM-118227