### PR TITLE
Block virtual joystick in Android

### DIFF
--- a/vendor/inputflinger.te
+++ b/vendor/inputflinger.te
@@ -1,0 +1,1 @@
+get_prop(inputflinger, vendor_virt_input_did_prop)

--- a/vendor/property.te
+++ b/vendor/property.te
@@ -1,0 +1,1 @@
+vendor_public_prop(vendor_virt_input_did_prop)

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -1,0 +1,1 @@
+persist.vendor.disable.deviceid u:object_r:vendor_virt_input_did_prop:s0

--- a/vendor/system_server.te
+++ b/vendor/system_server.te
@@ -1,0 +1,1 @@
+get_prop(system_server, vendor_virt_input_did_prop)

--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -4,3 +4,4 @@ allow vendor_init debugfs_tracing_instances:dir create_dir_perms;
 allow vendor_init debugfs_tracing_instances:file w_file_perms;
 allow vendor_init proc_swappiness:file w_file_perms;
 allow vendor_init proc_disk_based_swap:file w_file_perms;
+set_prop(vendor_init, vendor_virt_input_did_prop)


### PR DESCRIPTION
The virtual joystick generated by weston should be ignored by Android. This commit block virtual joystick by set persist.vendor.disable.deviceid to 1234:5678

Tracked-On: OAM-118932