### PR TITLE
Assign file label to the new teedata mount point

### DIFF
--- a/tee/optee/file_contexts
+++ b/tee/optee/file_contexts
@@ -6,7 +6,7 @@
 /vendor/bin/tee-supplicant    u:object_r:tee_exec:s0
 
 # optee secure storage using REE filesystem
-/persist(/.*)?                u:object_r:tee_data_file:s0
+/mnt/vendor/persist(/.*)?                u:object_r:tee_data_file:s0
 
 # optee keymaster and gatekeeper treble service
 /vendor/bin/hw/android.hardware.keymaster@3.0-service             u:object_r:hal_keymaster_default_exec:s0

--- a/tee/optee/tee.te
+++ b/tee/optee/tee.te
@@ -11,6 +11,7 @@ allow tee tee_device:blk_file rw_file_perms;
 allow tee tee_data_file:sock_file { write create };
 allow tee gsi_metadata_file:dir search;
 allow tee metadata_file:dir search;
+allow tee mnt_vendor_file:dir { getattr search };
 
 #============= xtest ==============
 # For xtest 200x tests


### PR DESCRIPTION
teedata partition's mount point is changed from /persist to /mnt/vendor/persist

Tracked-On: OAM-121938