### PR TITLE
Allow dumpstate to call automotive_display_service

### DIFF
--- a/car/dumpstate.te
+++ b/car/dumpstate.te
@@ -1,0 +1,1 @@
+binder_call(dumpstate, automotive_display_service_server);


### PR DESCRIPTION
This is used to fix a CTS failure:
'android.security.cts.SELinuxHostTest#testNoBugreportDenials' the relevant logs:
'java.lang.AssertionError: Found illegal SELinux denial(s):
    avc:  denied  { call } for  scontext=u:r:dumpstate:s0
    tcontext=u:r:automotive_display_service:s0 tclass=binder
    permissive=0'

Tracked-On: OAM-122069