### PR TITLE
Adding car UI lunch target

### DIFF
--- a/car/carservice_app.te
+++ b/car/carservice_app.te
@@ -4,5 +4,5 @@ allow carservice_app sysfs_fs_ext4_features:dir r_dir_perms;
 
 # To allow carservice app to  access sys.usb.cfg
 module_only(`carservice_app', `
-  set_prop(carservice_app, exported_system_radio_prop)
+  set_prop(carservice_app, usb_control_prop)
 ')

--- a/car/kitchensink_app.te
+++ b/car/kitchensink_app.te
@@ -1,8 +1,0 @@
-userdebug_or_eng(`
-  allow kitchensink_app {
-        textservices_service
-        bluetooth_manager_service
-        media_session_service
-        activity_task_service
-  }:service_manager find;
-')


### PR DESCRIPTION
Remove the diff patch from /vendor/intel/utils and apply it to device/intel/sepolicy directly.

Tracked-On: OAM-122232