### PR TITLE
Add sepolicy for application rendering setting property

### DIFF
--- a/app_render_setting_property/platform_app.te
+++ b/app_render_setting_property/platform_app.te
@@ -1,0 +1,1 @@
+get_prop(platform_app, vendor_intel_render_selection_prop)

--- a/app_render_setting_property/priv_app.te
+++ b/app_render_setting_property/priv_app.te
@@ -1,0 +1,1 @@
+get_prop(priv_app, vendor_intel_render_selection_prop)

--- a/app_render_setting_property/property.te
+++ b/app_render_setting_property/property.te
@@ -1,0 +1,2 @@
+vendor_public_prop(vendor_intel_render_selection_prop)
+typeattribute vendor_intel_render_selection_prop    extended_core_property_type;

--- a/app_render_setting_property/property_contexts
+++ b/app_render_setting_property/property_contexts
@@ -1,0 +1,1 @@
+persist.vendor.intel u:object_r:vendor_intel_render_selection_prop:s0

--- a/app_render_setting_property/system_app.te
+++ b/app_render_setting_property/system_app.te
@@ -1,0 +1,6 @@
+#
+# system_app
+#
+set_prop(system_app, vendor_intel_render_selection_prop)
+allow system_app vendor_intel_render_selection_prop:file { getattr map open };
+allow system_app vendor_intel_render_selection_prop:property_service set;

--- a/app_render_setting_property/system_server.te
+++ b/app_render_setting_property/system_server.te
@@ -1,0 +1,2 @@
+get_prop(system_server, vendor_intel_render_selection_prop)
+allow system_server vendor_intel_render_selection_prop:file read;

--- a/app_render_setting_property/untrusted_app_all.te
+++ b/app_render_setting_property/untrusted_app_all.te
@@ -1,0 +1,1 @@
+get_prop(untrusted_app_all, vendor_intel_render_selection_prop)

--- a/camera-ext/ivi/cameraserver.te
+++ b/camera-ext/ivi/cameraserver.te
@@ -1,0 +1,4 @@
+#============= cameraserver ==============
+allow cameraserver gpu_device:dir search;
+allow cameraserver gpu_device:chr_file rw_file_perms;
+allow cameraserver hal_graphics_allocator_default_tmpfs:file { read write map};

--- a/camera-ext/ivi/file_contexts
+++ b/camera-ext/ivi/file_contexts
@@ -1,4 +1,4 @@
-/dev/media[0-9]+          u:object_r:video_device:s0
+/dev/video[0-9]+          u:object_r:video_device:s0
 /(vendor|system/vendor)/bin/android\.hardware\.automotive\.evs@1\.[0-9]-sample  u:object_r:hal_evs_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.vendor\.hardware\.camera\.provider@2\.[0-9]+-ivi-service       u:object_r:hal_camera_default_exec:s0
-/(vendor|system/vendor)/bin/hw/android\.iacamera\.provider@2\.[0-9]+-ivi-service u:object_r:hal_camera_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.iacamera\.provider-ivi-service u:object_r:hal_camera_default_exec:s0

--- a/camera-ext/ivi/file_contexts
+++ b/camera-ext/ivi/file_contexts
@@ -1,0 +1,4 @@
+/dev/media[0-9]+          u:object_r:video_device:s0
+/(vendor|system/vendor)/bin/android\.hardware\.automotive\.evs@1\.[0-9]-sample  u:object_r:hal_evs_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.vendor\.hardware\.camera\.provider@2\.[0-9]+-ivi-service       u:object_r:hal_camera_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.iacamera\.provider@2\.[0-9]+-ivi-service u:object_r:hal_camera_default_exec:s0

--- a/camera-ext/ivi/hal_camera_default.te
+++ b/camera-ext/ivi/hal_camera_default.te
@@ -1,0 +1,10 @@
+#============= hal_camera_default ==============
+vndbinder_use(hal_camera_default);
+
+allow hal_camera_default gpu_device:chr_file rw_file_perms;
+allow hal_camera_default gpu_device:dir search;
+allow hal_camera_default hal_graphics_allocator_default_tmpfs:file { map read write };
+allow hal_camera_default hal_graphics_mapper_hwservice:hwservice_manager find;
+allow hal_camera_default hal_graphics_composer_default:fd use;
+allow hal_camera_default self:{ socket vsock_socket } { create read write listen accept bind };
+set_prop(hal_camera_default, vendor_camera_default_prop)

--- a/camera-ext/ivi/init.te
+++ b/camera-ext/ivi/init.te
@@ -1,0 +1,6 @@
+#
+# init
+#
+
+# wait on /dev/video0 a shared buffer used for camera processing
+allow init video_device:chr_file getattr;

--- a/camera-ext/ivi/logwrapper.te
+++ b/camera-ext/ivi/logwrapper.te
@@ -1,0 +1,1 @@
+set_prop(logwrapper, vendor_camera_default_prop)

--- a/camera-ext/ivi/property.te
+++ b/camera-ext/ivi/property.te
@@ -1,0 +1,1 @@
+vendor_internal_prop(vendor_camera_default_prop)

--- a/camera-ext/ivi/property_contexts
+++ b/camera-ext/ivi/property_contexts
@@ -1,0 +1,8 @@
+ro.vendor.remote.sf.fake_camera                 u:object_r:vendor_camera_default_prop:s0
+ro.vendor.camera.in_frame_format.h264 u:object_r:vendor_camera_default_prop:s0
+ro.vendor.camera.in_frame_format.i420 u:object_r:vendor_camera_default_prop:s0
+ro.vendor.camera.decode.vaapi         u:object_r:vendor_camera_default_prop:s0
+ro.vendor.remote.sf.back_camera_hal             u:object_r:vendor_camera_default_prop:s0
+ro.vendor.remote.sf.front_camera_hal            u:object_r:vendor_camera_default_prop:s0
+ro.vendor.camera.transference         u:object_r:vendor_camera_default_prop:s0 
+vendor.camera.external         u:object_r:vendor_camera_default_prop:s0 

--- a/camera-ext/ivi/service_contexts
+++ b/camera-ext/ivi/service_contexts
@@ -1,0 +1,1 @@
+android.hardware.camera.provider.ICameraProvider/ivi/0 u:object_r:hal_camera_service:s0

--- a/camera-ext/ivi/vendor_init.te
+++ b/camera-ext/ivi/vendor_init.te
@@ -1,0 +1,1 @@
+set_prop(vendor_init, vendor_camera_default_prop)

--- a/graphics/composer3/file_contexts
+++ b/graphics/composer3/file_contexts
@@ -1,0 +1,2 @@
+/(vendor|system/vendor)/bin/hw/android\.hardware\.graphics\.composer3-service\.intel u:object_r:hal_graphics_composer_default_exec:s0
+

--- a/graphics/composer3/violators_blacklist.te
+++ b/graphics/composer3/violators_blacklist.te
@@ -1,0 +1,1 @@
+typeattribute hal_graphics_composer_default data_between_core_and_vendor_violators;

--- a/power/android_pm_tune.te
+++ b/power/android_pm_tune.te
@@ -1,0 +1,37 @@
+# Rules for android_pm_tune script
+type android_pm_tune, domain;
+type android_pm_tune_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(android_pm_tune)
+
+allow android_pm_tune proc_cmdline:file r_file_perms;
+allow android_pm_tune proc:file rw_file_perms;
+allow android_pm_tune proc:file {getattr};
+allow android_pm_tune sysfs:dir r_dir_perms;
+allow android_pm_tune sysfs:file rw_file_perms;
+#allow android_pm_tune sysfs:file {getattr open write};
+allow android_pm_tune sysfs_net:dir r_dir_perms;
+allow android_pm_tune sysfs_net:file rw_file_perms;
+allow android_pm_tune sysfs_net:file {getattr};
+allow android_pm_tune sysfs_app_readable:file rw_file_perms;
+allow android_pm_tune sysfs_app_readable:dir r_dir_perms;
+allow android_pm_tune sysfs_app_readable:file {getattr};
+allow android_pm_tune sysfs_gfx:file {getattr};
+
+allow android_pm_tune dbc_sysfs:file {getattr};
+allow android_pm_tune dbc_sysfs:dir r_dir_perms;
+allow android_pm_tune dbc_sysfs:file rw_file_perms;
+
+allow android_pm_tune sysfs_virtio:file rw_file_perms;
+
+allow android_pm_tune vendor_file:file rx_file_perms;
+allow android_pm_tune proc_cpuinfo:file r_file_perms;
+allow android_pm_tune vendor_toolbox_exec:file execute_no_trans;
+
+not_full_treble(`
+  allow android_pm_tune system_file:file rx_file_perms;
+  allow android_pm_tune shell_exec:file rx_file_perms;
+')
+full_treble_only(`
+  allow android_pm_tune vendor_shell_exec:file rx_file_perms;
+  allow android_pm_tune vendor_toolbox_exec:file rx_file_perms;
+')

--- a/power/file_contexts
+++ b/power/file_contexts
@@ -2,3 +2,5 @@
 /(vendor|system/vendor)/bin/hw/android\.hardware\.power@[0-9]+.?[0-9]*-service          u:object_r:hal_power_service_exec:s0
 # Power HAL helper
 (/system)?/vendor/bin/power_hal_helper u:object_r:power_hal_helper_exec:s0
+# android_power_tune
+(/system)?/vendor/bin/android_pm_tune.sh u:object_r:android_pm_tune_exec:s0

--- a/power/shell.te
+++ b/power/shell.te
@@ -1,0 +1,1 @@
+allow shell android_pm_tune_exec:file getattr;

--- a/sensors/mediation/sensor_hal_default.te
+++ b/sensors/mediation/sensor_hal_default.te
@@ -5,3 +5,4 @@ allowxperm hal_sensors_default self:socket ioctl unpriv_sock_ioctls;
 allow hal_sensors_default serial_device:chr_file rw_file_perms;
 
 allow hal_sensors_default self:vsock_socket { create read write connect getopt setopt };
+allow hal_sensors_default hal_graphics_allocator_default_tmpfs:file { read write };

--- a/wlan/iwlwifi/genfs_contexts
+++ b/wlan/iwlwifi/genfs_contexts
@@ -1,0 +1,2 @@
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/ieee80211/phy0 u:object_r:sysfs_net:s0
+


### PR DESCRIPTION
All app need the read/write authorization
to the customized property presist.vendor.intel.*
for rendering option.

Tracked-On: OAM-122333