### PR TITLE
Add sepolicy for composer3 AIDL HAL service.

### DIFF
--- a/graphics/composer3/file_contexts
+++ b/graphics/composer3/file_contexts
@@ -1,0 +1,2 @@
+/(vendor|system/vendor)/bin/hw/android\.hardware\.graphics\.composer3-service\.intel u:object_r:hal_graphics_composer_default_exec:s0
+


### PR DESCRIPTION
From Android 13, used AIDL to define the Hardware Composer (HWC) HAL, and deprecated the HIDL version android.hardware.graphics.composer@2.1 to android.hardware.graphics.composer@2.4.

Tests Done: Boot check

Tracked-On: OAM-122744