### PR TITLE
Add sepolicy for application rendering setting property

### DIFF
--- a/app_render_setting_property/platform_app.te
+++ b/app_render_setting_property/platform_app.te
@@ -1,0 +1,1 @@
+get_prop(platform_app, vendor_intel_render_selection_prop)

--- a/app_render_setting_property/priv_app.te
+++ b/app_render_setting_property/priv_app.te
@@ -1,0 +1,1 @@
+get_prop(priv_app, vendor_intel_render_selection_prop)

--- a/app_render_setting_property/property.te
+++ b/app_render_setting_property/property.te
@@ -1,0 +1,2 @@
+vendor_public_prop(vendor_intel_render_selection_prop)
+typeattribute vendor_intel_render_selection_prop    extended_core_property_type;

--- a/app_render_setting_property/property_contexts
+++ b/app_render_setting_property/property_contexts
@@ -1,0 +1,2 @@
+persist.vendor.intel.dGPU u:object_r:vendor_intel_render_selection_prop:s0
+persist.vendor.intel.lowPir u:object_r:vendor_intel_render_selection_prop:s0

--- a/app_render_setting_property/system_app.te
+++ b/app_render_setting_property/system_app.te
@@ -1,0 +1,4 @@
+#
+# system_app
+#
+set_prop(system_app, vendor_intel_render_selection_prop)

--- a/app_render_setting_property/system_server.te
+++ b/app_render_setting_property/system_server.te
@@ -1,0 +1,1 @@
+get_prop(system_server, vendor_intel_render_selection_prop)

--- a/app_render_setting_property/untrusted_app_all.te
+++ b/app_render_setting_property/untrusted_app_all.te
@@ -1,0 +1,1 @@
+get_prop(untrusted_app_all, vendor_intel_render_selection_prop)


### PR DESCRIPTION
All app need the read/write authorization
to the customized property presist.vendor.intel.dGPU.*
and persist.vendor.intel.lowPir.* for rendering option.

Tracked-On: OAM-122333