### PR TITLE
Set proper file label for dri dir

### DIFF
--- a/graphics/mesa/file_contexts
+++ b/graphics/mesa/file_contexts
@@ -21,14 +21,10 @@
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.celadon\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libgrallocclient\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libglapi\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/dri/i965_dri\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/dri/iris_dri\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/dri/virtio_gpu_dri\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/dri/gallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/vulkan\.intel\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/dri/libgallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libmd\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/vulkan\.pastel\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/dri(/.*)?     u:object_r:same_process_hal_file:s0
 
 #coreu /data/vendor permission
 /data/vendor/coreu(/.*)?       u:object_r:coreu_data_file:s0


### PR DESCRIPTION
It seems all the libraries under /vendor/lib64/dri need to be accessed by some core domains. Set
same_process_hal_file label for the whole dir of /vendor/lib64/dri to avoid too many items in the
file_contexts file. And this can also fix an issue that if a dri library is pushed to dri dir after
remount and the device cannot boot up

Tracked-On: OAM-123676