### PR TITLE
Add sepolicy for app override service

### DIFF
--- a/app-override-service/service.te
+++ b/app-override-service/service.te
@@ -1,0 +1,1 @@
+type app_override_service, system_server_service, system_api_service, service_manager_type;

--- a/app-override-service/service_contexts
+++ b/app-override-service/service_contexts
@@ -1,0 +1,1 @@
+app_override                   u:object_r:app_override_service:s0

--- a/app-override-service/system_server.te
+++ b/app-override-service/system_server.te
@@ -1,0 +1,1 @@
+binder_call(system_server, app_override_service)


### PR DESCRIPTION
Fixed system_server crash due to AppOverrideService failed to start after enabled selinux feature.

Tracked-On: OAM-124492