### PR TITLE
Add sepolicy for mapper5 stable-c interface

### DIFF
--- a/graphics/mesa/hal_graphics_composer_default.te
+++ b/graphics/mesa/hal_graphics_composer_default.te
@@ -26,3 +26,4 @@ dontaudit hal_graphics_composer_default default_prop:file *;
 allow hal_graphics_composer_default sysfs:file { open read };
 allow hal_graphics_composer_default uio_device:chr_file { map open read write };
 allow hal_graphics_composer_default hal_graphics_allocator_default_tmpfs:file { read write map };
+allow hal_graphics_composer_default hal_graphics_mapper_service:service_manager find;

--- a/graphics/mesa/service_contexts
+++ b/graphics/mesa/service_contexts
@@ -1,0 +1,14 @@
+# "mapper/minigbm" represents "mapper.minigbm.so" which is a minigbm
+# implementation of mapper5 stable-c interface. This corresponds to the
+# VINTF manifest declaration:
+#    <hal format="native">
+#        <name>mapper</name>
+#        <version>5.0</version>
+#        <interface>
+#            <instance>minigbm</instance>
+#        </interface>
+#    </hal>
+# Note that native/passthrough HALs use the "{type}/{instance}" pattern from
+# SEPolicy perspective and are looked up via the corresponding filename
+# "{type}.{instance}.so".
+mapper/minigbm      u:object_r:hal_graphics_mapper_service:s0


### PR DESCRIPTION
Tests done:
- Android boot in BM & GVT-d config
- adb reboot

Tracked-On: OAM-124485
Tracked-On: OAM-124524