### PR TITLE
Sepolicy for android_pm_tune script

### DIFF
--- a/power/android_pm_tune.te
+++ b/power/android_pm_tune.te
@@ -1,0 +1,33 @@
+# Rules for android_pm_tune script
+type android_pm_tune, domain;
+type android_pm_tune_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(android_pm_tune)
+
+allow android_pm_tune proc_cmdline:file r_file_perms;
+allow android_pm_tune proc:file rw_file_perms;
+allow android_pm_tune sysfs:dir r_dir_perms;
+allow android_pm_tune sysfs:file rw_file_perms;
+allow android_pm_tune sysfs_net:dir r_dir_perms;
+allow android_pm_tune sysfs_net:file rw_file_perms;
+allow android_pm_tune sysfs_app_readable:file rw_file_perms;
+allow android_pm_tune sysfs_app_readable:dir r_dir_perms;
+allow android_pm_tune sysfs_gfx:file {getattr};
+
+allow android_pm_tune dbc_sysfs:dir r_dir_perms;
+allow android_pm_tune dbc_sysfs:file rw_file_perms;
+
+allow android_pm_tune sysfs_virtio:file rw_file_perms;
+
+allow android_pm_tune vendor_file:file rx_file_perms;
+allow android_pm_tune proc_cpuinfo:file r_file_perms;
+allow android_pm_tune vendor_toolbox_exec:file execute_no_trans;
+
+not_full_treble(`
+  allow android_pm_tune system_file:file rx_file_perms;
+  allow android_pm_tune shell_exec:file rx_file_perms;
+')
+full_treble_only(`
+  allow android_pm_tune vendor_shell_exec:file rx_file_perms;
+  allow android_pm_tune vendor_toolbox_exec:file rx_file_perms;
+')
+

--- a/power/file_contexts
+++ b/power/file_contexts
@@ -2,3 +2,5 @@
 /(vendor|system/vendor)/bin/hw/android\.hardware\.power@[0-9]+.?[0-9]*-service          u:object_r:hal_power_service_exec:s0
 # Power HAL helper
 (/system)?/vendor/bin/power_hal_helper u:object_r:power_hal_helper_exec:s0
+# android_power_tune
+(/system)?/vendor/bin/android_pm_tune.sh u:object_r:android_pm_tune_exec:s0

--- a/power/shell.te
+++ b/power/shell.te
@@ -1,0 +1,1 @@
+allow shell android_pm_tune_exec:file getattr;


### PR DESCRIPTION
Adding the required domain and rules for
executing android_pm_tune script to obtain
the power optimization during idle display
conditions.

Tests done : Logs

Tracked-On: OAM-125227