### PR TITLE
Fix trace error caused by wifi modules

### DIFF
--- a/wlan/load_iwl_modules/load_iwl_modules.te
+++ b/wlan/load_iwl_modules/load_iwl_modules.te
@@ -18,6 +18,7 @@ allow load_iwl_modules_script self:key write;
 allow load_iwl_modules_script kernel:key search;
 allow load_iwl_modules_script rootfs:file r_file_perms;
 allow load_iwl_modules_script vendor_file:file rx_file_perms;
+allow load_iwl_modules_script debugfs_wifi_tracing:dir search;
 
 not_full_treble(`
     allow load_iwl_modules_script shell_exec:file rx_file_perms;


### PR DESCRIPTION
This is a regession issue that caused by commit: c7bb847c504bcc "Load mac80211 module based on iwl7000_mac80211 module existence" The reason is that load_iwl_modules need search right to access trace node in /sys/kernel/debug/tracing. This patch adds search right for selinux.

Tracked-On: OAM-126168