### PR TITLE
Add graphics related sepolicy for hal_sensors_default

### DIFF
--- a/sensors/mediation/sensor_hal_default.te
+++ b/sensors/mediation/sensor_hal_default.te
@@ -5,3 +5,4 @@ allowxperm hal_sensors_default self:socket ioctl unpriv_sock_ioctls;
 allow hal_sensors_default serial_device:chr_file rw_file_perms;
 
 allow hal_sensors_default self:vsock_socket { create read write connect getopt setopt };
+allow hal_sensors_default hal_graphics_allocator_default_tmpfs:file { read write };


### PR DESCRIPTION
Fix VTS sensors issues.
-DirectChannelGralloc/0_android_hardware_sensors_ISensors_default

Test Done:
run vts -m VtsAidlHalSensorsTargetTest

Tracked-On: OAM-125128