### PR TITLE
Add a new SEPolicy macro of module_not_disable

### DIFF
--- a/rfkill/hal_bluetooth_vbt.te
+++ b/rfkill/hal_bluetooth_vbt.te
@@ -1,1 +1,3 @@
-allow hal_bluetooth_vbt rfkill_device:chr_file rw_file_perms;
+module_not_disable(`bluetooth', `
+  allow hal_bluetooth_vbt rfkill_device:chr_file rw_file_perms;
+')

--- a/te_macros
+++ b/te_macros
@@ -25,6 +25,11 @@ define(`target_only', `ifelse(eval(index(board_sepolicy_target_product, $1) >= 0
 # WARNING: <modname> cannot contain a dash, use underscores.
 define(`module_only', `ifelse(module_$1, `true', $2)')
 
+#####################################
+# module_not_disable(module_name, rules)
+# Only add rules if a module is not false.
+define(`module_not_disable', `ifelse(module_$1, `false', , $2)')
+
 # ignore_adb_debug(domain)
 # Some hal interface expose a forwarded port over adb
 # for debugging, ignore these. If you need to access


### PR DESCRIPTION
Add a new SEPolicy macro of module_not_disable, use this to wrap the sepolicy rules needed to be compiled if some module is disabled.

Tracked-On: OAM-127489