### PR TITLE
Allow untrusted_app find app_override_serivce

### DIFF
--- a/app-override-service/untrusted_app_all.te
+++ b/app-override-service/untrusted_app_all.te
@@ -1,0 +1,2 @@
+allow untrusted_app_all app_override_service:service_manager find;
+


### PR DESCRIPTION
Allow untrusted app to find app_override service for hotfix or workaround some 3rd party apps problem in our platform.

Tracked-On: OAM-124215