### PR TITLE
Resolve opencl cache creation fail in base_aaos

### DIFF
--- a/graphics/opencl/file_contexts
+++ b/graphics/opencl/file_contexts
@@ -6,6 +6,6 @@
 /(vendor|system/vendor)/lib(64)?/libopencl-clang\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libigc\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libigdgmm_android\.so u:object_r:same_process_hal_file:s0
-
+/(vendor|system/vendor)/lib(64)?/libbinder\.so u:object_r:same_process_hal_file:s0
 #icd file permission
 /vendor/Khronos/OpenCL/vendors/intel\.icd u:object_r:vendor_app_file:s0


### PR DESCRIPTION
Changes done:

-In multiuser mode APPs dont have access to /data/data/<progname>, thus add /data/user/userid/<progname>/.cache/neo_compiler_cache as 1st fallback cache dir for Android

- To get userid of particular thread we need to get uid from IPCThreadState, which is part of libbinder

- Add sepolicy for libbinder in opencl

Tests done:
- Android build
- Boot and verified with tflite gpu delegate with openCL

Tracked-On: OAM-127697