### PR TITLE
Add sepolicy for get and set of vendor.mesa.anv.queue.override

### DIFF
--- a/graphics/mesa/domain.te
+++ b/graphics/mesa/domain.te
@@ -1,1 +1,2 @@
 allow domain sysfs_app_readable:dir search;
+get_prop(coredomain, vendor_graphics_mesa_prop)

--- a/graphics/mesa/property.te
+++ b/graphics/mesa/property.te
@@ -1,2 +1,3 @@
 vendor_internal_prop(vendor_graphics_hwcomposer_prop)
 vendor_public_prop(vendor_graphics_gles_prop)
+vendor_restricted_prop(vendor_graphics_mesa_prop)

--- a/graphics/mesa/property_contexts
+++ b/graphics/mesa/property_contexts
@@ -1,2 +1,3 @@
 vendor.hwcomposer.edid.    u:object_r:vendor_graphics_hwcomposer_prop:s0
 vendor.gles.         u:object_r:vendor_graphics_gles_prop:s0
+vendor.mesa.         u:object_r:vendor_graphics_mesa_prop:s0

--- a/graphics/mesa/vendor_init.te
+++ b/graphics/mesa/vendor_init.te
@@ -4,3 +4,4 @@ dontaudit vendor_init debugfs_tracing_instances:dir write;
 allow vendor_init mediaserver:process setsched;
 allow vendor_init self:udp_socket create;
 dontaudit vendor_init coreu_data_file:dir create_dir_perms;
+set_prop(vendor_init, vendor_graphics_mesa_prop)


### PR DESCRIPTION
vendor.mesa.anv.queue.override is set in init.rc and read by mesa.

Tests done:
- Android boot with angle and vulkan as backend
- Video playback and recording
- adb reboot

Tracked-On: OAM-126014