### PR TITLE
Remove the genfs_context of /sys/class/udc

### DIFF
--- a/aafd/genfs_contexts
+++ b/aafd/genfs_contexts
@@ -1,4 +1,3 @@
 genfscon 9p / u:object_r:p9fs2:s0
-genfscon sysfs /class/udc u:object_r:sysfs_usb:s0
 genfscon debugfs /dri/0/i915_sriov_info u:object_r:debugfs_graphics:s0
 genfscon debugfs /dri/0/name u:object_r:debugfs_graphics:s0


### PR DESCRIPTION
This has potential conflict with GSI image and will cause the boot failure of GSI system.

Tracked-On: OAM-127013