### PR TITLE
Add sepolicy rules for vendor opencl lib property

### DIFF
--- a/graphics/opencl/appdomain.te
+++ b/graphics/opencl/appdomain.te
@@ -1,0 +1,2 @@
+get_prop(appdomain, vendor_opencl_lib_prop)
+

--- a/graphics/opencl/file_contexts
+++ b/graphics/opencl/file_contexts
@@ -7,5 +7,6 @@
 /(vendor|system/vendor)/lib(64)?/libigc\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libigdgmm_android\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libbinder\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/libclvk\.so u:object_r:same_process_hal_file:s0
 #icd file permission
 /vendor/Khronos/OpenCL/vendors/intel\.icd u:object_r:vendor_app_file:s0

--- a/graphics/opencl/property.te
+++ b/graphics/opencl/property.te
@@ -1,0 +1,2 @@
+vendor_public_prop(vendor_opencl_lib_prop)
+

--- a/graphics/opencl/property_contexts
+++ b/graphics/opencl/property_contexts
@@ -1,0 +1,2 @@
+vendor.opencl.lib    u:object_r:vendor_opencl_lib_prop:s0
+


### PR DESCRIPTION
Introduce a new sepolicy for the vendor.opencl.lib property. Add rules for accessing this from shell and application.

Tracked-On: OAM-128356