### PR TITLE
trusty: sepolicy for mock rpmb

### DIFF
--- a/tee/trusty/mock_rpmb/file.te
+++ b/tee/trusty/mock_rpmb/file.te
@@ -1,0 +1,1 @@
+type rpmb_mock_data_file, file_type, data_file_type;

--- a/tee/trusty/mock_rpmb/file_contexts
+++ b/tee/trusty/mock_rpmb/file_contexts
@@ -1,0 +1,4 @@
+# RPMB Mock
+/vendor/bin/rpmb_dev               u:object_r:rpmb_dev_mock_exec:s0
+/data/vendor/ss(/.*)?              u:object_r:rpmb_mock_data_file:s0
+

--- a/tee/trusty/mock_rpmb/init.te
+++ b/tee/trusty/mock_rpmb/init.te
@@ -1,0 +1,1 @@
+allow init socket_device:sock_file create_file_perms;

--- a/tee/trusty/mock_rpmb/rpmb_dev_mock_exec.te
+++ b/tee/trusty/mock_rpmb/rpmb_dev_mock_exec.te
@@ -1,0 +1,10 @@
+type rpmb_dev_mock, domain;
+type rpmb_dev_mock_exec, vendor_file_type, exec_type, file_type;
+
+init_daemon_domain(rpmb_dev_mock)
+
+#allow rpmb_dev_mock rpmb_mock_data_file:file create_file_perms;
+#allow rpmb_dev_mock rpmb_mock_data_file:dir create_dir_perms;
+
+allow rpmb_dev_mock mnt_vendor_file:file create_file_perms;
+allow rpmb_dev_mock mnt_vendor_file:dir create_dir_perms;

--- a/tee/trusty/mock_rpmb/tee.te
+++ b/tee/trusty/mock_rpmb/tee.te
@@ -1,0 +1,4 @@
+allow tee socket_device:sock_file rw_file_perms;
+allow tee rpmb_mock_data_file:file create_file_perms;
+allow tee rpmb_mock_data_file:dir create_dir_perms;
+allow tee rpmb_dev_mock:unix_stream_socket connectto;

--- a/tee/trusty/property.te
+++ b/tee/trusty/property.te
@@ -1,0 +1,2 @@
+vendor_internal_prop(vendor_trusty_storage_prop)
+

--- a/tee/trusty/property_contexts
+++ b/tee/trusty/property_contexts
@@ -1,0 +1,2 @@
+ro.vendor.trusty.storage.fs_ready               u:object_r:vendor_trusty_storage_prop:s0
+

--- a/tee/trusty/tee.te
+++ b/tee/trusty/tee.te
@@ -13,3 +13,4 @@ allow tee block_device:dir search;
 allow tee tee_device:blk_file rw_file_perms;
 allow tee gsi_metadata_file:dir search;
 allow tee metadata_file:dir search;
+set_prop(tee, vendor_trusty_storage_prop)


### PR DESCRIPTION
Enabling mock rpmb module sepolicy which is required for creating of the creation of mock RPMB in /data on boot up.

Tests Done:
1. Boot the device in MTL nuc.
2. storageproxyd service is running.

Tracked-On: OAM-128292