### PR TITLE
Grant logwrapper domain read permission for sysfs dirs/files

### DIFF
--- a/vendor/logwrapper.te
+++ b/vendor/logwrapper.te
@@ -4,3 +4,4 @@ type logwrapper_exec, exec_type, file_type, vendor_file_type;
 init_daemon_domain(logwrapper)
 
 allow logwrapper devpts:chr_file rw_file_perms;
+r_dir_file(logwrapper, sysfs_type)


### PR DESCRIPTION
logwrapper domain need read the /sys/class/udc dir to check the dwc status. However the file label for this dir changed in the GSI image, this cause logwrapper lose the read permission. Grant a more generic sysfs file access permission for logwrapper to resolve this issue.

Tracked-On: OAM-128815