### PR TITLE
update sepolicy for vhal

### DIFF
--- a/car/device.te
+++ b/car/device.te
@@ -1,0 +1,1 @@
+type spidev_device, dev_type;

--- a/car/file_contexts
+++ b/car/file_contexts
@@ -1,9 +1,13 @@
 /(vendor|system/vendor)/bin/hw/android\.hardware\.automotive\.vehicle\.intel@2\.0-service  u:object_r:hal_vehicle_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.hardware\.automotive\.vehicle\.intel@2\.1-service  u:object_r:hal_vehicle_default_exec:s0
 
+/(vendor|system/vendor)/bin/hw/android\.hardware\.automotive\.vehicle@intel-aidl-service  u:object_r:hal_vehicle_default_exec:s0
+
 /vendor/bin/hw/android.hardware.broadcastradio@intel-service u:object_r:hal_broadcastradio_default_exec:s0
 /vendor/bin/hw/android.hardware.automotive.audiocontrol@1.0-service.intel u:object_r:hal_audiocontrol_default_exec:s0
 
 /system/bin/evs_intel_app                                             u:object_r:evs_intel_app_exec:s0
 /system/bin/evs_app_support_lib                                 u:object_r:evs_intel_app_exec:s0
 /system/etc/automotive/evs(/.*)?                                u:object_r:evs_intel_app_files:s0
+
+/dev/spidev0\.0       u:object_r:spidev_device:s0

--- a/car/hal_vehicle_default.te
+++ b/car/hal_vehicle_default.te
@@ -21,6 +21,7 @@ allowxperm hal_vehicle_default self:can_socket ioctl {
 
 ignore_adb_debug(`hal_vehicle_default')
 
+allow hal_vehicle_default spidev_device:chr_file rw_file_perms;
 allow hal_vehicle_default serial_device:chr_file rw_file_perms;
 allow hal_vehicle_default sysfs_power:file rw_file_perms;
 allow hal_evs_default gpu_device:dir { read open};


### PR DESCRIPTION
add rule for intel-aidl vhal and /dev/spidev0.0

porting from android 14 aaos_iasw

Test Done:
  vhal can communicate with vMCU through spidev0.0

Tracked-On: OAM-129248