### PR TITLE
Grant vsock access permissions to gnss hal

### DIFF
--- a/gnss/hal_gnss_default.te
+++ b/gnss/hal_gnss_default.te
@@ -1,3 +1,4 @@
 allow hal_gnss_default usb_serial_device:chr_file rw_file_perms;
+allow hal_gnss_default self:vsock_socket create_socket_perms_no_ioctl;
 
 get_prop(hal_gnss_default, vendor_gnss_ser_prop)


### PR DESCRIPTION
To support gnss virtualization, gnss hal may need
to communicate with gnss backend through vsock.

Tracked-On: OAM-129470