### PR TITLE
BSP_DIFF cleanup

### DIFF
--- a/boot-arch/generic/device.te
+++ b/boot-arch/generic/device.te
@@ -3,6 +3,5 @@ type acpio_block_device, dev_type;
 type vendor_block_device, dev_type;
 type product_block_device, dev_type;
 type odm_block_device, dev_type;
-typeattribute system_block_device super_block_device_type;
 typeattribute vendor_block_device super_block_device_type;
 typeattribute product_block_device super_block_device_type;


### PR DESCRIPTION
Observed build issue due to never allow sepolicy for type attribute system_device_block.

Tests done: EB is build and booted successfully.

Tracked-On: OAM-127806