### PR TITLE
Add sepolicy for uvcvideo and virtvideo

### DIFF
--- a/camera-ext/ivi/file_contexts
+++ b/camera-ext/ivi/file_contexts
@@ -1,4 +1,6 @@
 /dev/video[0-9]+          u:object_r:video_device:s0
+/dev/uvcvideo[0-9]+          u:object_r:video_device:s0
+/dev/virtvideo[0-9]+          u:object_r:video_device:s0
 /(vendor|system/vendor)/bin/android\.hardware\.automotive\.evs@1\.[0-9]-sample  u:object_r:hal_evs_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.vendor\.hardware\.camera\.provider@2\.[0-9]+-ivi-service       u:object_r:hal_camera_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.iacamera\.provider-ivi-service u:object_r:hal_camera_default_exec:s0


### PR DESCRIPTION
Issue-Detailed: Renamed virtiocamera device to virtvideo.

Issue-Fixed: add the sepolicy for /dev/virtvideo* device.

Tested-On: Camera preview/capture/record works.

Tracked-On: OAM-129620