### PR TITLE
Add sepolicy for rdtsc

### DIFF
--- a/rdtsc/file_contexts
+++ b/rdtsc/file_contexts
@@ -1,0 +1,1 @@
+/vendor/bin/rdtsc               u:object_r:init_rdtsc_exec:s0

--- a/rdtsc/init_rdtsc.te
+++ b/rdtsc/init_rdtsc.te
@@ -1,0 +1,8 @@
+type init_rdtsc, domain;
+type init_rdtsc_exec, exec_type, vendor_file_type, file_type;
+
+init_daemon_domain(init_rdtsc)
+
+allow init_rdtsc vendor_shell_exec:file rx_file_perms;
+allow init_rdtsc vendor_toolbox_exec:file rx_file_perms;
+allow init_rdtsc sysfs_devices_system_cpu:file write;


### PR DESCRIPTION
rdtsc is used to read tsc to measure cold boot time, add sepolicy for it.

Tracked-On: OAM-129753