### PR TITLE
Fix ipu6ep firmware loading issue

### DIFF
--- a/kernel/kernel.te
+++ b/kernel/kernel.te
@@ -12,3 +12,7 @@ allow kernel kernel:capability sys_admin;
 # For loading /lib/modules/inet_diag.ko
 allow kernel rootfs:system module_load;
 allow kernel system_file:system module_load;
+
+# For loading /vendor/firmwares
+allow kernel vendor_file:dir r_dir_perms;
+allow kernel vendor_file:file r_file_perms;


### PR DESCRIPTION
Issue Detailed: Android14 secpolicy forbids to load the firmware files from /vendor/firmware/intel/ipu/

Issue Fixed: Modify kernel.te to allow to load firmwares from that path.

Issue Tested: Successfully load ipu6ep.bin which locates in the above path.

Trakced-On: OAM-129975