### PR TITLE
Adding Sepolicy permission for ethernet

### DIFF
--- a/ethernet/common/genfs_contexts
+++ b/ethernet/common/genfs_contexts
@@ -6,3 +6,80 @@ genfscon sysfs /devices/pci0000:00/0000:00:07.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:06.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7.4/1-7.4:1.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:09.0/virtio2/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7.1/1-7.1:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7.2/1-7.2:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7.3/1-7.3:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7.4/1-7.4:2.0/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-1/1-1:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-3/1-3:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-4/1-4:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-5/1-5:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-6/1-6:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-8/1-8:1.0/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-1/1-1:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-3/1-3:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-4/1-4:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-5/1-5:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-6/1-6:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-8/1-8:2.0/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-1/2-1:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-2/2-2:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-3/2-3:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-4/2-4:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-5/2-5:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-6/2-6:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-7/2-7:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-8/2-8:1.0/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-1/2-1:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-2/2-2:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-3/2-3:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-4/2-4:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-5/2-5:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-6/2-6:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-7/2-7:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-8/2-8:2.0/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-1/1-1:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-2/1-2:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-3/1-3:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-4/1-4:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-5/1-5:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-6/1-6:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-7/1-7:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-8/1-8:1.0/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-1/1-1:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-2/1-2:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-3/1-3:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-4/1-4:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-5/1-5:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-6/1-6:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-7/1-7:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb1/1-8/1-8:2.0/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-1/2-1:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-2/2-2:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-3/2-3:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-4/2-4:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-5/2-5:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-6/2-6:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-7/2-7:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-8/2-8:1.0/net u:object_r:sysfs_net:s0
+
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-1/2-1:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-2/2-2:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-3/2-3:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-4/2-4:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-5/2-5:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-6/2-6:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-7/2-7:2.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb2/2-8/2-8:2.0/net u:object_r:sysfs_net:s0


### PR DESCRIPTION
genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb*/*/*/net
    u:object_r:sysfs_net:s0

genfscon sysfs /devices/pci0000:00/0000:00:07.0/usb*/*/*/net
    u:object_r:sysfs_net:s0

This SELinux policy configuration specifies the security context for the eth1..* interface.This ensures the permissions are set correctly for the eth1..* interface to function as expected. The eth1..* pci bus id is 6 on MBL CRB and 7 on MBL RVP platform.

Multiple policy configuration are added because diff ethernet adapters have diff path configuration

Tests:
     Android boot up success
     adb connection through IP success
     All CTS testcase passed

merging bsp diff patches

Tracked-On: OAM-130073