### PR TITLE
Fix sepolicy for netd_integration_test

### DIFF
--- a/ethernet/common/genfs_contexts
+++ b/ethernet/common/genfs_contexts
@@ -4,7 +4,9 @@ genfscon sysfs /devices/pci0000:00/0000:00:13.1/0000:02:00.0/net u:object_r:sysf
 genfscon sysfs /devices/pci0000:00/0000:00:04.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:07.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:06.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:08.0/net/ u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7.4/1-7.4:1.0/net u:object_r:sysfs_net:s0
+genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb2/2-4/2-4.4/2-4.4:1.0/net u:object_r:sysfs_net:s0
 genfscon sysfs /devices/pci0000:00/0000:00:09.0/virtio2/net u:object_r:sysfs_net:s0
 
 genfscon sysfs /devices/pci0000:00/0000:00:06.0/usb1/1-7/1-7.1/1-7.1:2.0/net u:object_r:sysfs_net:s0


### PR DESCRIPTION
Add missing sepolicy for NetdSELinuxTest#CheckProperMTULabels case

Test done: netd_integration_test64

Tracked-On: https://jira.devtools.intel.com/browse/OAM-129963