### PR TITLE
Add sepolicy for data dump related properties of mediasdk_c2

### DIFF
--- a/codec2/msdk-codec2/codec2_hal_default.te
+++ b/codec2/msdk-codec2/codec2_hal_default.te
@@ -55,3 +55,5 @@ allow codec2_hal_default hwservicemanager:binder call;
 allow codec2_hal_default tombstoned_crash_socket:sock_file write;
 allow codec2_hal_default sysfs_gpu:dir search;
 allow codec2_hal_default sysfs_gpu:file { getattr open read };
+
+set_prop(codec2_hal_default, vendor_c2_dump);

--- a/codec2/msdk-codec2/property.te
+++ b/codec2/msdk-codec2/property.te
@@ -1,0 +1,1 @@
+vendor_internal_prop(vendor_c2_dump)

--- a/codec2/msdk-codec2/property_contexts
+++ b/codec2/msdk-codec2/property_contexts
@@ -1,0 +1,1 @@
+vendor.c2.dump. u:object_r:vendor_c2_dump:s0


### PR DESCRIPTION
Because of no sepolicy for data dump related properties, lots of logs printed during codec, like: W libc : Access denied finding property "c2.decoder.dump.output.number".

So add sepolicy for dump related properties.

Tracked-On: OAM-131307