### PR TITLE
Label sysfs dir for ivshmem based virtio-GPU

### DIFF
--- a/graphics/mesa/genfs_contexts
+++ b/graphics/mesa/genfs_contexts
@@ -3,6 +3,7 @@ genfscon proc /sys/dev/i915/ u:object_r:proc_graphics:s0
 genfscon sysfs /devices/pci0000:00/0000:00:02.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:01.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:03.0/ u:object_r:sysfs_app_readable:s0
+genfscon sysfs /devices/pci0000:00/0000:00:11.1/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:04.0/ u:object_r:sysfs_gpu:s0
 genfscon sysfs /devices/pci0000:00/0000:00:09.0/ u:object_r:sysfs_app_readable:s0
 genfscon sysfs /devices/pci0000:00/0000:00:08.0/ u:object_r:sysfs_app_readable:s0


### PR DESCRIPTION
Let App that allocates buffers with minigbm be able to access files in ivshmem based virtio-GPU directory under sysfs. This is essential in the process of detecting virtio-GPU device reserved for usage in LIC (Linux in Container).