### PR TITLE
Change hwc service name

### DIFF
--- a/graphics/composer3/file_contexts
+++ b/graphics/composer3/file_contexts
@@ -1,2 +1,2 @@
-/(vendor|system/vendor)/bin/hw/android\.hardware\.graphics\.composer3-service\.intel u:object_r:hal_graphics_composer_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.hardware\.composer\.hwc3-service\.drm u:object_r:hal_graphics_composer_default_exec:s0
 


### PR DESCRIPTION
Change hwc service name to
android.hardware.composer.hwc3-service.drm, since
hwc sync upstream.

Tracked-On: OAM-131262