### PR TITLE
Use vpblit to convert UYVY to NV21

### DIFF
--- a/camera-ext/ivi/hal_camera_default.te
+++ b/camera-ext/ivi/hal_camera_default.te
@@ -3,6 +3,12 @@ vndbinder_use(hal_camera_default);
 
 allow hal_camera_default gpu_device:chr_file rw_file_perms;
 allow hal_camera_default gpu_device:dir search;
+
+hal_client_domain(hal_camera_default, hal_graphics_allocator)
+allow hal_camera_default hal_graphics_allocator_default:binder call;
+allow hal_camera_default hal_graphics_allocator_hwservice:hwservice_manager find;
+allow hal_camera_default hal_graphics_allocator_service:service_manager find;
+
 allow hal_camera_default hal_graphics_allocator_default_tmpfs:file { map read write };
 allow hal_camera_default hal_graphics_mapper_hwservice:hwservice_manager find;
 allow hal_camera_default hal_graphics_composer_default:fd use;


### PR DESCRIPTION
Issue Detailed: iacamera provider needs to allocate gfx buffer to convert UYVY to NV21, which is forbidden by seplicy and triggers segment faults.

Issue Fixed: Add new rules to allow iacamera provider to allocate gfxbuffer.

Tested-On: iacamera provider can start up correctly.

Tracked-On: OAM-132124