### PR TITLE
Fix AVC denial for the software Gatekeeper

### DIFF
--- a/tee/trusty/hal_gatekeeper_default.te
+++ b/tee/trusty/hal_gatekeeper_default.te
@@ -1,0 +1,2 @@
+hal_attribute_service(hal_gatekeeper, hal_gatekeeper_service)
+allow hal_gatekeeper_default hal_gatekeeper_service:service_manager add;

--- a/tee/trusty/service_contexts
+++ b/tee/trusty/service_contexts
@@ -1,0 +1,1 @@
+android.hardware.security.sharedsecret.ISharedSecret/gatekeeper                      u:object_r:hal_gatekeeper_service:s0


### PR DESCRIPTION
Gatekeeper unable to boot due to AVC Denial

create service context for the gatekeeper
service and adding to the servicemanager

Tests done:
1.Gatekeeper atarted on boot up
2.set device lock and unlock

Tracked-On: OAM-132238