### PR TITLE
Grant kernel read permissions for unlabeled files

### DIFF
--- a/kernel/kernel.te
+++ b/kernel/kernel.te
@@ -12,3 +12,7 @@ allow kernel kernel:capability sys_admin;
 # For loading /lib/modules/inet_diag.ko
 allow kernel rootfs:system module_load;
 allow kernel system_file:system module_load;
+
+userdebug_or_eng(`
+  allow kernel unlabeled:file r_file_perms;
+')


### PR DESCRIPTION
Kernel needs to read files from /vendor/firmware, however, overlayfs is mounted over system/vendor/odm/product partitions after adb remount. The default file label in overlayfs is u:object_r:unlabeled:s0.

Tracked-On: OAM-126223