### PR TITLE
Add new process name of HWC service

### DIFF
--- a/graphics/composer3/file_contexts
+++ b/graphics/composer3/file_contexts
@@ -1,2 +1,3 @@
 /(vendor|system/vendor)/bin/hw/android\.hardware\.graphics\.composer3-service\.intel u:object_r:hal_graphics_composer_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.hardware\.composer\.hwc3-service\.drm u:object_r:hal_graphics_composer_default_exec:s0
 


### PR DESCRIPTION
The new version of drm-hwcomposer changes the process name of HWC service. Add it to sepolicy.